### PR TITLE
Default Clan Cleanup

### DIFF
--- a/Management-Server/src/main/java/ms/ServerConstants.java
+++ b/Management-Server/src/main/java/ms/ServerConstants.java
@@ -35,11 +35,6 @@ public final class ServerConstants {
 	public static final String HOST_ADDRESS = "127.0.0.1";
 
 	/**
-	 * The setting that determines whether new accounts created will automatically join the Server's default clan chat.
-	 */
-	public static boolean  NEW_PLAYER_DEFAULT_CLAN = true;
-
-	/**
 	 * The store path.
 	 */
 	public static final String STORE_PATH = "./store/";

--- a/Server/src/main/java/Server/core/ServerConstants.java
+++ b/Server/src/main/java/Server/core/ServerConstants.java
@@ -172,8 +172,7 @@ public final class ServerConstants {
 		 * empty.
 		 */
 	}
-	
-	public static final Boolean NEW_PLAYER_DEFAULT_CLAN = true;
+
 	public static final String SERVER_NAME = "2009Scape";
 	
 }

--- a/Server/src/main/java/Server/core/game/world/GameSettings.kt
+++ b/Server/src/main/java/Server/core/game/world/GameSettings.kt
@@ -76,6 +76,7 @@ class GameSettings
         val msAddress: String,
         val default_xp_rate: Double,
         val allow_slayer_reroll: Boolean,
+        val enable_default_clan: Boolean,
         val enable_bots: Boolean,
         val autostock_ge: Boolean,
         val allow_token_purchase: Boolean
@@ -123,6 +124,7 @@ class GameSettings
                 val ipAddress = settings.getAttribute("msip")
                 val defaultXpRate = settings.getAttribute("default_xp_rate").toDouble()
                 val allowSlayerReroll = settings.getAttribute("allow_slayer_reroll")!!.toBoolean()
+                val enableDefaultClan = settings.getAttribute("enable_default_clan")!!.toBoolean()
                 val enableBots = settings.getAttribute("enable_bots")!!.toBoolean()
                 val autostockGe = settings.getAttribute("autostock_ge")!!.toBoolean()
                 val allow_token_purchase = settings.getAttribute("allow_token_purchase")!!.toBoolean()
@@ -139,7 +141,7 @@ class GameSettings
                         }
                     }
                 }
-                return GameSettings(name, beta, devMode, startGui, worldId, countryId, activity, true, pvp, false, false, ipAddress,defaultXpRate,allowSlayerReroll,enableBots,autostockGe,allow_token_purchase)
+                return GameSettings(name, beta, devMode, startGui, worldId, countryId, activity, true, pvp, false, false, ipAddress,defaultXpRate,allowSlayerReroll,enableDefaultClan,enableBots,autostockGe,allow_token_purchase)
             } catch (e: Exception) {
                 e.printStackTrace()
             }

--- a/Server/src/main/java/Server/core/net/registry/AccountRegister.java
+++ b/Server/src/main/java/Server/core/net/registry/AccountRegister.java
@@ -16,6 +16,7 @@ import core.game.system.SystemManager;
 import core.game.system.mysql.SQLEntryHandler;
 import core.game.system.mysql.SQLManager;
 import core.game.system.task.TaskExecutor;
+import core.game.world.GameWorld;
 import core.net.Constants;
 import core.net.IoSession;
 import core.net.event.LoginReadEvent;
@@ -165,16 +166,8 @@ public class AccountRegister extends SQLEntryHandler<RegistryDetails> {
 		statement.setInt(5, entry.getCountry());
 		statement.setTimestamp(6, new Timestamp(System.currentTimeMillis()));
 
-		//If the management server's settings register new users with the server's clan chat
-		//I believe if there was no entry there would be errors during the registration, hence a null entry if the setting is off
-		if(ServerConstants.NEW_PLAYER_DEFAULT_CLAN)
-		{
-			statement.setString(7,ServerConstants.SERVER_NAME.toLowerCase());
-		}else{
-			statement.setString(7,null);
-		}
-		
-		statement.setString(7, "2009scape");
+		statement.setString(7, GameWorld.getSettings().getEnable_default_clan() ? ServerConstants.SERVER_NAME.toLowerCase(): null);
+
 		statement.executeUpdate();
 		SQLManager.close(statement.getConnection());
 	}

--- a/Server/worldprops/server1.xml
+++ b/Server/worldprops/server1.xml
@@ -14,6 +14,7 @@
     msip="127.0.0.1"
     default_xp_rate="5"
     allow_slayer_reroll="false"
+    enable_default_clan="true"
     enable_bots="true"
     autostock_ge="true"
     allow_token_purchase="true"


### PR DESCRIPTION
**Describe what changes you made in this pull request, preferably with bullet points.**
- Moved the NEW_PLAYER_DEFAULT_CLAN into the world property files, now labelled as 'enable_default_clan'
- Removed the unused NEW_PLAYER_DEFAULT_CLAN variable from the Management and Game Servers
- 'Simplified' the check in AccountRegister.java, which is now based off the True/False status of the 'enable_default_clan' attribute in the properties file.

**List the issues that this pull request closes here**

- Doesn't close any outstanding issues on github, but may help with the issue of new players not joining the server clanchat automatically on account creation/first time login (though, I would be lying if I said I was able to reproduce the issue).

**Add any relevant info here**
<br/>
- I'd recommend changing the 2009Scape member's clanName and currentClan values to '2009scape' from '2009Scape'.
- The clan name is set to lowercase because text on the server only capitalizes the first letter in a sentence. There were issues earlier where players couldn't join '2009Scape' because clanchat (and text in general) would interpret their request as '2009scape'. IDK if RS had case sensitivity for names and chatbox back then, might be worth investigating.
- Still kind of figuring things out, and it's the first time I've worked with Kotlin stuff. Let me know if anything in this commit needs changing.