### PR TITLE
Cook's Assistant Rewrite

### DIFF
--- a/Server/src/main/java/Server/core/game/node/entity/player/link/quest/Quest.java
+++ b/Server/src/main/java/Server/core/game/node/entity/player/link/quest/Quest.java
@@ -27,6 +27,11 @@ public abstract class Quest implements Plugin<Object> {
 	public static final String BLUE = "<col=08088A>";
 
 	/**
+	 * Represents the black string.
+	 */
+	public static final String BLACK = "<col=000000>";
+
+	/**
 	 * The constant representing the journal component.
 	 */
 	public static final int JOURNAL_COMPONENT = 275;
@@ -144,7 +149,7 @@ public abstract class Quest implements Plugin<Object> {
 				line++;
 			}
 		} else {
-			send = send.replace("!!",RED).replace("??",BLUE);
+			send = send.replace("!!",RED).replace("??",BLUE).replace("---",BLACK + "<str>").replace("/--", BLUE);
 			line(player, send, line, false);
 		}
 	}

--- a/Server/src/main/java/Server/plugin/quest/free/cooksassistant/CooksAssistant.kt
+++ b/Server/src/main/java/Server/plugin/quest/free/cooksassistant/CooksAssistant.kt
@@ -64,7 +64,7 @@ class CooksAssistant : Quest("Cook's Assistant",15, 14, 1, 29, 0, 1, 2){
             }
 
             //If the player has handed everything in but was interrupted the final dialogue
-            if (player.getAttribute("cooks_assistant:all_submitted", false)) {
+            if (player.getAttribute("cooks_assistant:all_submitted", false) || (player.getAttribute("cooks_assistant:milk_submitted", false) && player.getAttribute("cooks_assistant:flour_submitted", false) && player.getAttribute("cooks_assistant:egg_submitted", false))) {
                 line(player,"I should return to the !!Cook.??", line)
             }
 

--- a/Server/src/main/java/Server/plugin/quest/free/cooksassistant/CooksAssistant.kt
+++ b/Server/src/main/java/Server/plugin/quest/free/cooksassistant/CooksAssistant.kt
@@ -1,0 +1,107 @@
+package plugin.quest.free.cooksassistant
+
+import core.game.node.entity.player.Player
+import core.game.node.entity.player.link.quest.Quest
+import core.plugin.InitializablePlugin
+import plugin.skill.Skills
+
+@InitializablePlugin
+class CooksAssistant : Quest("Cook's Assistant",15, 14, 1, 29, 0, 1, 2){
+    val MILK = 1927
+    val FLOUR = 1933
+    val EGG = 1944
+
+    override fun drawJournal(player: Player?, stage: Int) {
+
+        super.drawJournal(player, stage)
+
+        var line = 12
+        var stage = player?.questRepository?.getStage("Cook's Assistant")!!
+
+
+        if(stage < 10){ //If the quest has not been started
+
+            line(player,"I can start this quest by speaking to the !!Cook?? in the", line++)
+            line(player,"!!Kitchen?? on the ground floor of !!Lumbridge Castle.??", line)
+
+        } else if (stage in 10..99) { //Player has started Cook's Assistant
+
+            //Situation
+            line(player,"It's the !!Duke of Lumbridge's?? birthday and I have to help", line++)
+            line(player,"his !!Cook?? make him a !!birthday cake.?? To do this I need to", line++)
+            line(player,"bring him the following ingredients:", line++)
+
+            //MILK
+            if (player.getAttribute("cooks_assistant:milk_submitted", false) || player.getAttribute("cooks_assistant:all_submitted", false)) { //If the player has handed in the bucket of milk
+                line(player,"<str>I have given the cook a bucket of milk.</str>", line++)
+            } else if (player.inventory.contains(MILK, 1)){ // If the player has a bucket of milk in their inventory
+                line(player, "I have found a !!bucket of milk?? to give to the cook.", line++)
+            } else { //If the player satisfies none of the above
+                line(player,"I need to find a !!bucket of milk.?? There's a cattle field east", line++)
+                line(player,"of Lumbridge, I should make sure I take an empty bucket", line++)
+                line(player, "with me.", line++)
+            }
+
+            //FLOUR
+            if (player.getAttribute("cooks_assistant:flour_submitted", false) || player.getAttribute("cooks_assistant:all_submitted", false)) { //If the player has handed in the pot of flour
+                line(player,"<str>I have given the cook a pot of flour.</str>", line++)
+            } else if (player.inventory.contains(FLOUR, 1)){ // If the player has a pot of flour in their inventory
+                line(player, "I have found a !!pot of flour?? to give to the cook.", line++)
+            } else { //If the player satisfies none of the above
+                line(player,"I need to find a !!pot of flour.?? There's a mill found north-", line++)
+                line(player,"west of Lumbridge, I should take an empty pot with me.", line++)
+            }
+
+            //EGG
+            if (player.getAttribute("cooks_assistant:egg_submitted", false) || player.getAttribute("cooks_assistant:all_submitted", false)) { //If the player has handed in the egg
+                line(player,"<str>I have given the cook an egg.</str>", line++)
+            } else if (player.inventory.contains(EGG, 1)){ // If the player has an egg in their inventory
+                line(player, "I have found an !!egg?? to give to the cook.", line++)
+            } else { //If the player satisfies none of the above
+                line(player,"I need to find an !!egg.?? The cook normally gets his eggs from", line++)
+                line(player,"the Groats' farm, found just to the west of the cattle", line++)
+                line(player,"field.", line)
+            }
+
+            //If the player has handed everything in but was interrupted the final dialogue
+            if (player.getAttribute("cooks_assistant:all_submitted", false)) {
+                line(player,"I should return to the !!Cook.??", line)
+            }
+
+        } else if (stage >= 100) { //If the player has completed the quest
+            line(player,"<str>It was the Duke of Lumbridge's birthday,  but his cook had</str>", line++)
+            line(player,"<str>forgotten to buy the ingredients he needed to make him a</str>", line++)
+            line(player,"<str>cake. I brought the cook an egg, some flour and some milk</str>", line++)
+            line(player,"<str>and then cook made a delicious looking cake with them.</str>", line++)
+            line += 1
+            line(player,"<str>As a reward he now lets me use his high quality range</str>", line++)
+            line(player,"<str>which lets me burn things less whenever I wish to cook</str>",line++)
+            line(player,"<str>there.</str>", line++)
+            line += 1
+            line(player,"<col=FF0000>QUEST COMPLETE!</col>",line)
+        }
+    }
+
+    //The Quest Finish Certificate
+    override fun finish(player: Player) {
+        var ln = 10
+        super.finish(player)
+        player.packetDispatch.sendString("You have completed the Cook's Assistant Quest!", 277, 4)
+        player.packetDispatch.sendItemZoomOnInterface(1891, 240, 277, 5)
+
+        drawReward(player,"1 Quest Point", ln++)
+        drawReward(player,"300 Cooking XP", ln)
+        player.skills.addExperience(Skills.COOKING, 300.0)
+
+        //Removing these attributes in the event that they weren't already cleared in the Cook's Dialogue
+        player.removeAttribute("cooks_assistant:milk_submitted")
+        player.removeAttribute("cooks_assistant:flour_submitted")
+        player.removeAttribute("cooks_assistant:egg_submitted")
+        player.removeAttribute("cooks_assistant:all_submitted")
+        player.removeAttribute("cooks_assistant:submitted_some_items")
+    }
+
+    override fun newInstance(`object`: Any?): Quest {
+        return this
+    }
+}

--- a/Server/src/main/java/Server/plugin/quest/free/cooksassistant/CooksAssistant.kt
+++ b/Server/src/main/java/Server/plugin/quest/free/cooksassistant/CooksAssistant.kt
@@ -33,7 +33,7 @@ class CooksAssistant : Quest("Cook's Assistant",15, 14, 1, 29, 0, 1, 2){
 
             //MILK
             if (player.getAttribute("cooks_assistant:milk_submitted", false) || player.getAttribute("cooks_assistant:all_submitted", false)) { //If the player has handed in the bucket of milk
-                line(player,"<str>I have given the cook a bucket of milk.</str>", line++)
+                line(player,"---I have given the cook a bucket of milk./--", line++)
             } else if (player.inventory.contains(MILK, 1)){ // If the player has a bucket of milk in their inventory
                 line(player, "I have found a !!bucket of milk?? to give to the cook.", line++)
             } else { //If the player satisfies none of the above
@@ -44,7 +44,7 @@ class CooksAssistant : Quest("Cook's Assistant",15, 14, 1, 29, 0, 1, 2){
 
             //FLOUR
             if (player.getAttribute("cooks_assistant:flour_submitted", false) || player.getAttribute("cooks_assistant:all_submitted", false)) { //If the player has handed in the pot of flour
-                line(player,"<str>I have given the cook a pot of flour.</str>", line++)
+                line(player,"---I have given the cook a pot of flour./--", line++)
             } else if (player.inventory.contains(FLOUR, 1)){ // If the player has a pot of flour in their inventory
                 line(player, "I have found a !!pot of flour?? to give to the cook.", line++)
             } else { //If the player satisfies none of the above
@@ -54,7 +54,7 @@ class CooksAssistant : Quest("Cook's Assistant",15, 14, 1, 29, 0, 1, 2){
 
             //EGG
             if (player.getAttribute("cooks_assistant:egg_submitted", false) || player.getAttribute("cooks_assistant:all_submitted", false)) { //If the player has handed in the egg
-                line(player,"<str>I have given the cook an egg.</str>", line++)
+                line(player,"---I have given the cook an egg./--", line++)
             } else if (player.inventory.contains(EGG, 1)){ // If the player has an egg in their inventory
                 line(player, "I have found an !!egg?? to give to the cook.", line++)
             } else { //If the player satisfies none of the above
@@ -69,14 +69,14 @@ class CooksAssistant : Quest("Cook's Assistant",15, 14, 1, 29, 0, 1, 2){
             }
 
         } else if (stage >= 100) { //If the player has completed the quest
-            line(player,"<str>It was the Duke of Lumbridge's birthday,  but his cook had</str>", line++)
-            line(player,"<str>forgotten to buy the ingredients he needed to make him a</str>", line++)
-            line(player,"<str>cake. I brought the cook an egg, some flour and some milk</str>", line++)
-            line(player,"<str>and then cook made a delicious looking cake with them.</str>", line++)
+            line(player,"---It was the Duke of Lumbridge's birthday,  but his cook had/--", line++)
+            line(player,"---forgotten to buy the ingredients he needed to make him a/--", line++)
+            line(player,"---cake. I brought the cook an egg, some flour and some milk/--", line++)
+            line(player,"---and then cook made a delicious looking cake with them./--", line++)
             line += 1
-            line(player,"<str>As a reward he now lets me use his high quality range</str>", line++)
-            line(player,"<str>which lets me burn things less whenever I wish to cook</str>",line++)
-            line(player,"<str>there.</str>", line++)
+            line(player,"---As a reward he now lets me use his high quality range/--", line++)
+            line(player,"---which lets me burn things less whenever I wish to cook/--",line++)
+            line(player,"---there./--", line++)
             line += 1
             line(player,"<col=FF0000>QUEST COMPLETE!</col>",line)
         }

--- a/Server/src/main/java/Server/plugin/quest/free/cooksassistant/GillieGroatsDialogue.kt
+++ b/Server/src/main/java/Server/plugin/quest/free/cooksassistant/GillieGroatsDialogue.kt
@@ -1,0 +1,68 @@
+package plugin.quest.free.cooksassistant
+
+import core.game.node.entity.player.Player
+import core.plugin.InitializablePlugin
+import plugin.dialogue.DialoguePlugin
+import plugin.dialogue.FacialExpression
+
+@InitializablePlugin
+class GillieGroatsDialogue (player: Player? = null) : DialoguePlugin(player){
+
+    override fun open(vararg args: Any?): Boolean {
+        var milk = false
+        if (args.size == 2) milk = true
+        if (milk) { //If the player attempts to milk a dairy cow without a bucket
+            npc(FacialExpression.LAUGH, "Tee hee! You've never milked a cow before, have you?")
+            stage = 100
+            return true
+        }
+        npc(FacialExpression.HAPPY, "Hello, I'm Gillie the Milkmaid. What can I do for you?")
+        stage = 0
+        return true
+    }
+
+    override fun handle(interfaceId: Int, buttonId: Int): Boolean {
+        when (stage) {
+
+            //If the player talks to Gillie directly
+            0 -> options("Who are you?", "Can you tell me how to milk a cow?", "I'm fine, thanks.").also { stage++ }
+            1 -> when(buttonId) {
+                1 -> npc(FacialExpression.HAPPY, "My name's Gillie Groats. My father is a farmer and I", "milk the cows for him.").also { stage = 10 }
+                2 -> player(FacialExpression.ASKING, "So how do you get milk from a cow then?").also { stage = 20 }
+                3 -> player(FacialExpression.NEUTRAL, "I'm fine, thanks.").also { stage = 1000 }
+            }
+
+            //Who are you?
+            10 -> player(FacialExpression.ASKING, "Do you have any buckets of milk spare?").also { stage++ }
+            11 -> npc(FacialExpression.SUSPICIOUS, "I'm afraid not. We need all of our milk to sell to", "market, but you can milk the cow yourself if you need", "milk.").also { stage++ }
+            12 -> player(FacialExpression.HAPPY,"Thanks.").also { stage = 1000 }
+
+            //Can you tell me how to milk a cow?
+            20 -> npc(FacialExpression.FRIENDLY, "It's very easy. First you need an empty bucket to hold", "the milk.").also { stage++ }
+            21 -> npc(FacialExpression.FRIENDLY, "Then find a dairy cow to milk - you can't milk just", "any cow.").also { stage++ }
+            22 -> player(FacialExpression.ASKING, "How do I find a dairy cow?").also { stage++ }
+            23 -> npc(FacialExpression.FRIENDLY, "They are easy to spot - they are dark brown and", "white, unlike beef cows, which are light brown and white.", "We also tether them to a post to stop them wandering", "around all over the place.").also {stage++ }
+            24 -> npc(FacialExpression.FRIENDLY, "There are a couple very near, in this field.").also { stage++ }
+            25 -> npc(FacialExpression.HAPPY, "Then just milk the cow and your bucket will fill with", "tasty, nutritious milk.").also { stage = 1000 }
+
+            //Continuation of attempting to milk a dairy cow without a bucket
+            100 -> player(FacialExpression.ASKING, "Erm... No. How could you tell?").also { stage++ }
+            101 -> npc(FacialExpression.LAUGH, "Because you're spilling milk all over the floor. What a","waste ! You need something to hold the milk.").also { stage++ }
+            102 -> player(FacialExpression.NEUTRAL, "Ah yes, I really should have guessed that one, shouldn't", "I?").also { stage++ }
+            103 -> npc(FacialExpression.LAUGH, "You're from the city, aren't you... Try it again with an","empty bucket.").also{ stage++ }
+            104 -> player(FacialExpression.NEUTRAL,"Right, I'll do that.").also { stage = 1000 }
+
+            //Dialogue Endpoint
+            1000 -> end()
+        }
+        return true
+    }
+
+    override fun newInstance(player: Player?): DialoguePlugin {
+        return GillieGroatsDialogue(player)
+    }
+
+    override fun getIds(): IntArray {
+        return intArrayOf(3807)
+    }
+}

--- a/Server/src/main/java/Server/plugin/quest/free/cooksassistant/LumbridgeCookDialogue.kt
+++ b/Server/src/main/java/Server/plugin/quest/free/cooksassistant/LumbridgeCookDialogue.kt
@@ -1,0 +1,261 @@
+package plugin.quest.free.cooksassistant
+
+import core.game.node.entity.player.Player
+import core.game.node.item.Item
+import core.plugin.InitializablePlugin
+import plugin.dialogue.DialoguePlugin
+import plugin.dialogue.FacialExpression
+
+@InitializablePlugin
+class LumbridgeCookDialogue (player: Player? = null) : DialoguePlugin(player){
+
+    //Item declaration
+    val EMPTY_BUCKET = 1925
+    val MILK = 1927
+    val EMPTY_POT = 1931
+    val FLOUR = 1933
+    val EGG = 1944
+
+    //Default settings for the Cook checking for ingredients in the player's inventory
+    var gave = false
+    var leftoverItems = ""
+
+
+    override fun open(vararg args: Any?): Boolean {
+        if (player?.questRepository?.getQuest("Cook's Assistant")!!.getStage(player) <= 0) { //If the player has ot started cook's assistant
+            npc(FacialExpression.SAD, "What am I to do?")
+            stage = 0
+            return true
+        } else if (player?.questRepository?.getQuest("Cook's Assistant")!!.getStage(player) in 10..99) { //During the Cook's Assistant Quest
+            if (player.getAttribute("cooks_assistant:all_submitted", false) || (player.getAttribute("cooks_assistant:milk_submitted", false) && player.getAttribute("cooks_assistant:flour_submitted", false) && player.getAttribute("cooks_assistant:egg_submitted", false))){ //If the player has handed all the ingredients to the chef but did not continue the dialogue
+                npc(FacialExpression.HAPPY, "You've brought me everything I need! I am saved!", "Thank you!")
+                stage = 200
+                return true
+            } else { //If the player has not handed all the items to the chef
+                npc(FacialExpression.SAD, "How are you getting on with finding the ingredients?")
+                stage = 100
+                return true
+            }
+        }
+        //After completing Cook's Assistant
+        npc(FacialExpression.HAPPY, "Hello friend, how is the adventuring going?")
+        stage = 300
+        return true
+    }
+
+    override fun handle(interfaceId: Int, buttonId: Int): Boolean {
+        when (stage) {
+            0 -> options("What's wrong?", "Can you make me a cake?", "You don't look very happy.", "Nice hat!").also { stage++ }
+            1 -> when(buttonId) {
+                1 -> player(FacialExpression.NEUTRAL, "What's wrong?").also { stage = 10 }
+                2 -> player(FacialExpression.ASKING, "You're a cook, why don't you bake me a cake?").also { stage = 20 }
+                3 -> player(FacialExpression.NEUTRAL,"You don't look very happy.").also { stage = 30; }
+                4 -> player(FacialExpression.HAPPY, "Nice hat!").also { stage = 40 }
+            }
+
+            //What's wrong?
+            10 -> npc(FacialExpression.SCARED, "Oh dear, oh dear, oh dear, I'm in a terrible terrible", "mess! It's the Duke's birthday today, and I should be", "making him a lovely big birthday cake.").also { stage++ }
+            11 -> npc(FacialExpression.SAD, "I've forgotten to buy the ingredients. I'll never get", "them in time now. He'll sack me! What will I do? I have", "four children and a goat to look after. Would you help", "me? Please?").also { stage++ }
+            12 -> options("I'm always happy to help a cook in distress.", "I can't right now, Maybe later.").also { stage++ }
+            13 -> when(buttonId) {
+                1 -> player(FacialExpression.HAPPY, "Yes, I'll help you.").also { stage = 50 }
+                2 -> player(FacialExpression.ANNOYED, "No, I don't feel like it. Maybe later.").also { stage++ }
+            }
+
+            //I can't right now
+            14 -> npc(FacialExpression.SAD, "Fine. I always knew you Adventurer types were callous", "beasts. Go on your merry way!").also { stage = 1000 }
+
+            //Can you make me a cake?
+            20 -> npc(FacialExpression.SAD, "*sniff* Don't talk to me about cakes...").also { stage++ }
+            21 -> player(FacialExpression.NEUTRAL, "What's wrong?").also { stage = 10}
+
+            //You don't look very happy
+            30 -> npc(FacialExpression.SAD, "No, I'm not. The world is caving in around me - I am", "overcome by dark feelings of impending doom.").also { stage++ }
+            31 -> options("What's wrong?","I'd take the rest of the day off if I were you.").also { stage++ }
+            32 -> when(buttonId) {
+                1 -> player(FacialExpression.NEUTRAL, "What's wrong?").also { stage = 10}
+                2 -> player(FacialExpression.NEUTRAL,"I'd take the rest of the day off if I were you.").also { stage++ }
+            }
+            33 -> npc(FacialExpression.SAD,"No, that's the worst thing I could do. I'd get in terrible","trouble.").also { stage++ }
+            34 -> player(FacialExpression.ASKING,"Well maybe you need to take a holiday...").also { stage++ }
+            35 -> npc(FacialExpression.SAD,"That would be nice, but the Duke doesn't allow holidays","for core staff").also { stage++ }
+            36 -> player(FacialExpression.SUSPICIOUS,"Hmm, why not run away to the sea and start a new","life as a Pirate?").also { stage++ }
+            37 -> npc(FacialExpression.SAD,"My wife gets sea sick, and I have an irational fear of","eyepatches. I don't see it working myself.").also { stage++ }
+            38 -> player(FacialExpression.NEUTRAL,"I'm afraid I've run out of ideas.").also { stage++ }
+            39 -> npc(FacialExpression.SAD,"I know I'm doomed.").also { stage = 21 }
+
+            //Nice hat!
+            40 -> npc(FacialExpression.SAD, "Er, thank you. It's a pretty ordinary cook's hat, really.").also { stage++ }
+            41 -> player(FacialExpression.HAPPY, "Still, it suits you. The trousers are pretty special too.").also { stage++ }
+            42 -> npc(FacialExpression.SAD, "It's all standard-issue cook's uniform.").also { stage++ }
+            43 -> player(FacialExpression.HAPPY, "The whole hat, apron, stripy trousers ensemble. It", "works. It makes you looks like a real cook.").also { stage++ }
+            44 -> npc(FacialExpression.ANGRY, "I AM a real cook! I haven't got time to be chatting", "about culinary fashion. I'm in desperate need of help!").also { stage = 21 }
+
+            //Yes, I'll help you
+            50 -> npc(FacialExpression.HAPPY, "Oh thank you, thank you. I need milk, an egg and", "flour. I'd be very grateful if you can get them for me.").also{ player?.questRepository?.getQuest("Cook's Assistant")?.start(player!!); stage++ }
+            51 -> player(FacialExpression.NEUTRAL, "So where do I find these ingredients then?").also { stage = 60 }
+
+            //Where do I find these ingredients?
+            60 -> options("Where do I find some flour?","How about milk?","And eggs? Where are they found?","Actually, I know where to find this stuff.").also { stage++ }
+            61 -> when(buttonId) {
+                1 -> npc(FacialExpression.NEUTRAL,"There is a Mill fairly close, go North and then West.","Mill Lane Mill is just off the road to Draynor. I","usually get my flour from there.").also {stage = 70 }
+                2 -> npc(FacialExpression.NEUTRAL,"There is a cattle field on the other side of the river,","just across the road from the Groats' Farm.").also { stage = 71 }
+                3 -> npc(FacialExpression.NEUTRAL,"I normally get my eggs from the Groats' farm, on the","other side of the river.").also { stage = 73 }
+                4 -> player(FacialExpression.NEUTRAL,"Actually, I know where to find this stuff.").also { stage = 1000 }
+            }
+
+            //Where do I find some flour?
+            70 -> npc(FacialExpression.SUSPICIOUS,"Talk to Millie, she'll help, she's a lovely girl and a fine","Miler. Make sure you take a pot with you for the flour","though, " + if (player.inventory.contains(EMPTY_POT, 1)) "you've got one on you already." else "there should be one on the table in here.").also { stage = 80 }
+
+            //How about milk?
+            71 -> npc(FacialExpression.SUSPICIOUS,"Talk to Gillie Groats, she looks after the Dairy cows -","she'll tell you everything you need to know about","milking cows!").also { stage++ }
+            72 ->
+                if (player.inventory.contains(EMPTY_BUCKET , 1)) {
+                        npc(FacialExpression.NEUTRAL,"You'll need an empty bucket for the milk itself. I do see", "you've got a bucket with you already luckily!").also { stage = 80 }
+                } else {
+                    npc(FacialExpression.NEUTRAL,"You'll need an empty bucket for the milk itself. The", "general store just north of the castle will sell you one", "for a couple of coins.").also { stage = 80 }
+                }
+
+            //And Eggs?
+            73 -> npc(FacialExpression.NEUTRAL,"But any chicken should lay eggs.").also { stage = 80 }
+
+            //Alternative menu for "Where do I find these ingredients?"
+            80 -> options("Where do I find some flour?","How about milk?","And eggs? Where are they found?","I've got all the information I need. Thanks.").also { stage++ }
+            81 -> when(buttonId) {
+                1 -> npc(FacialExpression.NEUTRAL,"There is a Mill fairly close, go North and then West.","Mill Lane Mill is just off the road to Draynor. I","usually get my flour from there.").also {stage = 70 }
+                2 -> npc(FacialExpression.NEUTRAL,"There is a cattle field on the other side of the river,","just across the road from the Groats' Farm.").also { stage = 71 }
+                3 -> npc(FacialExpression.NEUTRAL,"I normally get my eggs from the Groats' farm, on the","other side of the river.").also { stage = 73 }
+                4 -> player(FacialExpression.NEUTRAL,"I've got all the information I need. Thanks.").also { stage = 1000 }
+            }
+
+            //Code for checking the ingredients
+            100 ->
+                gave = false.also {//Default false to ensure that it checks the items
+
+                    //If the player has not submitted the item but has it in their inventory
+                    if (!player.getAttribute("cooks_assistant:milk_submitted", false) && player.inventory.contains(MILK, 1)) {
+                        player.setAttribute("/save:cooks_assistant:milk_submitted", true).also {
+                            player(FacialExpression.HAPPY, "Here's a bucket of milk.");
+                            player.inventory.remove(Item(MILK));
+                            gave = true
+                        }
+                    }
+                    if (!player.getAttribute("cooks_assistant:flour_submitted", false) && player.inventory.contains(FLOUR, 1)) {
+                        player.setAttribute("/save:cooks_assistant:flour_submitted", true).also {
+                            player(FacialExpression.HAPPY, "Here's a pot of flour.");
+                            player.inventory.remove(Item(FLOUR));
+                            gave = true
+
+                        }
+                    }
+                    if (!player.getAttribute("cooks_assistant:egg_submitted", false) && player.inventory.contains(EGG, 1)) {
+                        player.setAttribute("/save:cooks_assistant:egg_submitted", true).also {
+                            player(FacialExpression.HAPPY, "Here's a fresh egg.");
+                            player.inventory.remove(Item(EGG));
+                            gave = true
+                        }
+                    }
+
+                    //If the player gave an item to the Lumbridge cook
+                    if (gave) {
+
+                        //If this is the first time the player gave an item (or items) to the Lumbridge cook
+                        if (!player.getAttribute("cooks_assistant:submitted_some_items", false)) {
+                            player.setAttribute("/save:cooks_assistant:submitted_some_items", true)
+                        }
+
+                        //If the player has now handed in all the ingredients
+                        if (player.getAttribute("cooks_assistant:milk_submitted", false) && player.getAttribute("cooks_assistant:flour_submitted", false) && player.getAttribute("cooks_assistant:egg_submitted", false)) {
+                            npc(FacialExpression.HAPPY, "You've brought me everything I need! I am saved!", "Thank you!").also { player.setAttribute("/save:cooks_assistant:all_submitted",true); stage = 200 }
+                        } else {
+                            npc(FacialExpression.WORRIED,"Thanks for the ingredients you have got so far, please get","the rest quickly. I'm running out of time! The Duke","will throw me into the streets!").also { stage = 151 }
+                        }
+
+                    } else { //If the player did not give an item to the Lumbridge cook
+
+                        //If the player also has never submitted anything before
+                        if (!player.getAttribute("cooks_assistant:submitted_some_items",false)) {
+                            player(FacialExpression.NEUTRAL,"I haven't gotten any of them yet, I'm still looking.").also { stage = 155 }
+                        } else {
+                            options("I'll get right on it.","Can you remind me how to find these things again?").also { stage = 161 }
+                        }
+                    }
+                }
+
+            //If the player has submitted some ingredients but not all of them
+            150 -> npc(FacialExpression.WORRIED,"Thanks for the ingredients you have got so far, please get","the rest quickly. I'm running out of time! The Duke","will throw me into the streets!").also { stage++ }
+
+            //Checking what the player has left over
+            151 -> leftoverItems = "".also{
+                if (!player.getAttribute("cooks_assistant:milk_submitted", false)){
+                    leftoverItems += "A bucket of milk. ";
+                }
+                if (!player.getAttribute("cooks_assistant:flour_submitted", false)){
+                    leftoverItems += "A pot of flour. ";
+                }
+                if (!player.getAttribute("cooks_assistant:egg_submitted", false)){
+                    leftoverItems += "An egg.";
+                }
+                if (leftoverItems != ""){
+                    sendDialogue("You still need to get:",leftoverItems).also {stage = 160}
+                } else {
+                    npc(FacialExpression.HAPPY, "You've brought me everything I need! I am saved!", "Thank you!").also { player.setAttribute("/save:cooks_assistant:all_submitted",true); stage = 200 }
+                }
+            }
+
+            //If the player has yet to collect or hand in any of the ingredients
+            155 -> npc(FacialExpression.WORRIED,"Please get the ingredients quickly. I'm running out of","time! The Duke will throw me into the streets!").also { stage++ }
+            156 -> sendDialogue("You still need to get:", "A bucket of milk. A pot of flour. An egg.").also { stage = 160 }
+
+
+            // Menu after checking the items handed in
+            160 -> options("I'll get right on it.","Can you remind me how to find these things again?").also { stage++ }
+            161 -> when(buttonId) {
+                1 -> player(FacialExpression.NEUTRAL,"I'll get right on it.").also { stage = 1000 }
+                2 -> player(FacialExpression.ASKING,"Can you remind me how to find these things again?").also { stage = 60 }
+            }
+
+            //Final Cooks Assistant Dialogue
+            200 -> player(FacialExpression.HAPPY, "So do I get to go to the Duke's Party?").also { stage++ }
+            201 -> npc(FacialExpression.SAD, "I'm afraid not, only the big cheeses get to dine with the", "Duke.").also { stage++ }
+            202 -> player(FacialExpression.NEUTRAL, "Well, maybe one day I'll be important enough to sit on", "the Duke's table.").also { stage ++ }
+            203 -> npc(FacialExpression.NEUTRAL, "Maybe, but I won't be holding my breath.").also { stage++ }
+
+            //Activate the Cook's Assistant Quest Complete Certificate
+            204 -> end().also { player?.questRepository?.getQuest("Cook's Assistant")?.finish(player!!) }
+
+            //Dialogue after Cook's Assistant Completion
+            300 -> options("I am getting strong and mighty.", "I keep on dying.", "Can I use your range?").also { stage++ }
+            301 -> when (buttonId) {
+                1 -> player(FacialExpression.HAPPY, "I am getting strong and mighty. Grrr").also { stage = 310 }
+                2 -> player(FacialExpression.SAD, "I keep on dying.").also { stage = 320 }
+                3 -> player(FacialExpression.ASKING, "Can I use your range?").also { stage = 330 }
+            }
+
+            //I am getting strong and mighty
+            310 -> npc(FacialExpression.HAPPY,"Glad to hear it!").also { stage = 1000 }
+
+            //I keep on dying
+            320 -> npc(FacialExpression.HAPPY, "Ah, well, at least you keep coming back to life too!").also { stage = 1000 }
+
+            //Can I use your range?
+            330 -> npc(FacialExpression.HAPPY, "Go ahead! It's a very good range; it's better than most" ,"other ranges.").also { stage++ }
+            331 -> npc(FacialExpression.NEUTRAL, "It's called the Cook-o-Matic 100 and it uses a combination","of state-of-the-art temperature regulation and magic.").also { stage++ }
+            332 -> player(FacialExpression.ASKING,"Will it mean my food will burn less often?").also { stage++ }
+            333 -> npc(FacialExpression.NEUTRAL,"Well, that's what the salesman told us anyway...").also { stage++ }
+            334 -> player(FacialExpression.THINKING, "Thanks?").also { stage = 1000 }
+
+            //Conversation Endpoint
+            1000 -> end()
+        }
+        return true
+    }
+
+    override fun newInstance(player: Player?): DialoguePlugin {
+        return LumbridgeCookDialogue(player)
+    }
+
+    override fun getIds(): IntArray {
+        return intArrayOf(278)
+    }
+}

--- a/Server/src/main/java/Server/plugin/quest/free/cooksassistant/LumbridgeCookDialogue.kt
+++ b/Server/src/main/java/Server/plugin/quest/free/cooksassistant/LumbridgeCookDialogue.kt
@@ -135,11 +135,16 @@ class LumbridgeCookDialogue (player: Player? = null) : DialoguePlugin(player){
                     //If the player has not submitted the item but has it in their inventory
                     if (!player.getAttribute("cooks_assistant:milk_submitted", false) && player.inventory.contains(MILK, 1)) {
                         player.setAttribute("/save:cooks_assistant:milk_submitted", true).also {
-                            player(FacialExpression.HAPPY, "Here's a bucket of milk.");
-                            player.inventory.remove(Item(MILK));
+                            player(FacialExpression.HAPPY, "Here's a bucket of milk.")
+                            player.inventory.remove(Item(MILK))
                             gave = true
                         }
                     }
+                    stage++
+                }
+            101 ->
+                gave = gave.also {
+
                     if (!player.getAttribute("cooks_assistant:flour_submitted", false) && player.inventory.contains(FLOUR, 1)) {
                         player.setAttribute("/save:cooks_assistant:flour_submitted", true).also {
                             player(FacialExpression.HAPPY, "Here's a pot of flour.");
@@ -148,6 +153,11 @@ class LumbridgeCookDialogue (player: Player? = null) : DialoguePlugin(player){
 
                         }
                     }
+                    stage++
+                }
+            102 ->
+                gave = gave.also {
+
                     if (!player.getAttribute("cooks_assistant:egg_submitted", false) && player.inventory.contains(EGG, 1)) {
                         player.setAttribute("/save:cooks_assistant:egg_submitted", true).also {
                             player(FacialExpression.HAPPY, "Here's a fresh egg.");
@@ -155,30 +165,31 @@ class LumbridgeCookDialogue (player: Player? = null) : DialoguePlugin(player){
                             gave = true
                         }
                     }
+                    stage++
+                }
+            103 ->
+                //If the player gave an item to the Lumbridge cook
+                if (gave) {
 
-                    //If the player gave an item to the Lumbridge cook
-                    if (gave) {
+                    //If this is the first time the player gave an item (or items) to the Lumbridge cook
+                    if (!player.getAttribute("cooks_assistant:submitted_some_items", false)) {
+                        player.setAttribute("/save:cooks_assistant:submitted_some_items", true)
+                    }
 
-                        //If this is the first time the player gave an item (or items) to the Lumbridge cook
-                        if (!player.getAttribute("cooks_assistant:submitted_some_items", false)) {
-                            player.setAttribute("/save:cooks_assistant:submitted_some_items", true)
-                        }
+                    //If the player has now handed in all the ingredients
+                    if (player.getAttribute("cooks_assistant:milk_submitted", false) && player.getAttribute("cooks_assistant:flour_submitted", false) && player.getAttribute("cooks_assistant:egg_submitted", false)) {
+                        npc(FacialExpression.HAPPY, "You've brought me everything I need! I am saved!", "Thank you!").also { player.setAttribute("/save:cooks_assistant:all_submitted",true); stage = 200 }
+                    } else {
+                        npc(FacialExpression.WORRIED,"Thanks for the ingredients you have got so far, please get","the rest quickly. I'm running out of time! The Duke","will throw me into the streets!").also { stage = 151 }
+                    }
 
-                        //If the player has now handed in all the ingredients
-                        if (player.getAttribute("cooks_assistant:milk_submitted", false) && player.getAttribute("cooks_assistant:flour_submitted", false) && player.getAttribute("cooks_assistant:egg_submitted", false)) {
-                            npc(FacialExpression.HAPPY, "You've brought me everything I need! I am saved!", "Thank you!").also { player.setAttribute("/save:cooks_assistant:all_submitted",true); stage = 200 }
-                        } else {
-                            npc(FacialExpression.WORRIED,"Thanks for the ingredients you have got so far, please get","the rest quickly. I'm running out of time! The Duke","will throw me into the streets!").also { stage = 151 }
-                        }
+                } else { //If the player did not give an item to the Lumbridge cook
 
-                    } else { //If the player did not give an item to the Lumbridge cook
-
-                        //If the player also has never submitted anything before
-                        if (!player.getAttribute("cooks_assistant:submitted_some_items",false)) {
-                            player(FacialExpression.NEUTRAL,"I haven't gotten any of them yet, I'm still looking.").also { stage = 155 }
-                        } else {
-                            options("I'll get right on it.","Can you remind me how to find these things again?").also { stage = 161 }
-                        }
+                    //If the player also has never submitted anything before
+                    if (!player.getAttribute("cooks_assistant:submitted_some_items",false)) {
+                        player(FacialExpression.NEUTRAL,"I haven't gotten any of them yet, I'm still looking.").also { stage = 155 }
+                    } else {
+                        options("I'll get right on it.","Can you remind me how to find these things again?").also { stage = 161 }
                     }
                 }
 

--- a/Server/src/main/java/Server/plugin/quest/free/cooksassistant/MillieMillerDialogue.kt
+++ b/Server/src/main/java/Server/plugin/quest/free/cooksassistant/MillieMillerDialogue.kt
@@ -1,0 +1,65 @@
+package plugin.quest.free.cooksassistant
+
+import core.ServerConstants
+import core.game.node.entity.player.Player
+import core.plugin.InitializablePlugin
+import plugin.dialogue.DialoguePlugin
+import plugin.dialogue.FacialExpression
+
+@InitializablePlugin
+class MillieMillerDialogue (player: Player? = null) : DialoguePlugin(player) {
+
+    override fun open(vararg args: Any?): Boolean {
+
+        npc(FacialExpression.HAPPY, "Hello Adventurer. Welcome to Mill Lane Mill. Can I", "help you?")
+        stage = 0
+        return true
+    }
+
+    override fun handle(interfaceId: Int, buttonId: Int): Boolean {
+        when (stage) {
+
+            //Continuation of Millie's greeting
+            0 -> options("Who are you?", "What is this place?", "How do I mill flour?", "I'm fine, thanks.").also { stage++ }
+            1 -> when (buttonId) {
+                1 -> player(FacialExpression.ASKING,"Who are you?").also { stage = 10 }
+                2 -> player(FacialExpression.ASKING,"What is this place?").also { stage = 20 }
+                3 -> player(FacialExpression.ASKING, "How do I mill flour?").also { stage = 30 }
+                4 -> player(FacialExpression.NEUTRAL,"I'm fine, thanks.").also { stage = 1000 }
+            }
+
+            //Who are you?
+            10 -> npc(FacialExpression.FRIENDLY,"I'm Miss Millicent Miller the Miller of Mill Lane Mill.","Our family have been milling flour for generations.").also { stage = 10 }
+            11 -> player(FacialExpression.FRIENDLY,"It's a good business to be in. People will always need","flour.").also { stage++ }
+            12 -> player(FacialExpression.ASKING,"How do I mill flour?").also { stage = 30 }
+
+            //What is this place?
+            20 -> npc(FacialExpression.SUSPICIOUS,"This is Mill Lane Mill. Millers of the finest flour in", ServerConstants.SERVER_NAME + ", and home to the Miller family for many","generations").also { stage++ }
+            21 -> npc(FacialExpression.HAPPY,"We take grain from the field nearby and mill into flour.").also { stage++ }
+            22 -> player(FacialExpression.ASKING, "How do I mill flour?").also { stage = 30 }
+
+            //How do I mill flour?
+            30 -> npc(FacialExpression.FRIENDLY, "Making flour is pretty easy. First of all you need to", "get some grain. You can pick some from wheat fields.","There is one just outside the Mill, but there are many","others scattered across " + ServerConstants.SERVER_NAME + ". Feel free to pick wheat").also { stage++ }
+            31 -> npc(FacialExpression.FRIENDLY,"from our field! There always seems to be plenty of","wheat there.").also { stage++ }
+            32 -> player(FacialExpression.ASKING, "Then I bring my wheat here?").also { stage++ }
+            33 -> npc(FacialExpression.FRIENDLY,"Yes, or one of the other mills in " + ServerConstants.SERVER_NAME +". They all work","the same way. Just take your grain to the top floor of","the mill (up two ladders, there are three floors including","this one) and then place some grain in to the hopper.").also { stage++ }
+            34 -> npc(FacialExpression.HAPPY, "Then you need to start the grinding process by pulling","the hopper lever. You can add more grain, but each","time you add grain you have to pul the hopper lever","again.").also { stage++ }
+            35 -> player(FacialExpression.ASKING,"So where does the flour go then?").also { stage++ }
+            36 -> npc(FacialExpression.SUSPICIOUS,"The flour appears in this room here, you'll need a pot","to put the flour into. One pot will hold the flour made","by one load of grain").also { stage++ }
+            37 -> npc(FacialExpression.HAPPY,"And that's it! You now have some pots of finely ground","flour of the highest quality. Ideal for making tasty cakes","or delicous bread. I'm not a cook so you'll have to ask a","cook to ind out how to bake things.").also { stage++ }
+            38 -> npc(FacialExpression.HAPPY,"Great! Thanks for your help.").also { stage = 1000 }
+
+            //Conversation Endpoint
+            1000 -> end()
+        }
+        return true
+    }
+
+    override fun newInstance(player: Player?): DialoguePlugin {
+        return MillieMillerDialogue(player)
+    }
+
+    override fun getIds(): IntArray {
+        return intArrayOf(3806)
+    }
+}


### PR DESCRIPTION
**Things that were changed with this pull request:**
- Added correct dialogues for Millie Miller
- Added correct journal entries for the Cook's Assistant quest
- Added Facial Expressions or each character involved in the quest
- Moved files to the separate free quests package
- Removed need for using the QuestData.java file
- Reduced the line count of each file? (Kotlin makes this easier to do, so I don't really count it)

**List the issues that this pull request closes here**
- None

**Add any relevant info here**
- There is a bug with what I have written in the LumbridgeCookDialogue.kt file. When handing the ingredients to the cook, it will not activate the line of dialogue associated with the action. The issue is around lines 136 - 158, and it activates everything else except for the dialogue in those if statements (e.g. "Here's a fresh egg", "Here is a bucket of milk.", and "here is a pot of flour"). I'm out of ideas on how to fix it other than making the dialogues their own separate stages. As far as I know there the rest of the quest is fine. ~~Should have been addressed with commit `ddce480`~~ Didn't work out as well as I had hoped.
- **You will have to delete LumbridgeCookDialogue.java, MilleMiller.java, GillieGroatsDialogue.java, and CooksAssistant.java for these to work.**