### PR TITLE
GE bot sell database

### DIFF
--- a/Server/src/main/java/Server/core/Server.kt
+++ b/Server/src/main/java/Server/core/Server.kt
@@ -11,6 +11,7 @@ import core.net.NioReactor
 import core.net.amsc.WorldCommunicator
 import core.tools.TimeStamp
 import core.tools.backup.AutoBackup
+import plugin.ge.BotGrandExchange
 import plugin.ge.GEAutoStock
 import java.io.File
 import java.net.BindException
@@ -79,6 +80,7 @@ object Server {
         SystemLogger.log(GameWorld.getName() + " flags " + GameWorld.getSettings().toString())
         SystemLogger.log(GameWorld.getName() + " started in " + t.duration(false, "") + " milliseconds.")
         GEAutoStock.parse("data" + File.separator + "eco" + File.separator + "itemstostock.xml")
+        BotGrandExchange.loadOffersFromDB()
         // TODO Run the eco kick starter 1 time for the live server then comment it out
 //		ResourceManager.kickStartEconomy();
     }

--- a/Server/src/main/java/Server/plugin/ai/general/ScriptAPI.kt
+++ b/Server/src/main/java/Server/plugin/ai/general/ScriptAPI.kt
@@ -30,6 +30,7 @@ import plugin.consumable.Consumable
 import plugin.consumable.Consumables
 import plugin.consumable.Food
 import plugin.consumable.effects.HealingEffect
+import plugin.ge.BotGrandExchange
 import plugin.ge.GEOfferDispatch
 import plugin.ge.GrandExchangeOffer
 import plugin.ge.OfferState
@@ -353,12 +354,10 @@ class ScriptAPI(private val bot: Player) {
     fun sellOnGE(id: Int){
         class toCounterPulse : MovementPulse(bot,Location.create(3165, 3487, 0) ){
             override fun pulse(): Boolean {
-                val offer = GrandExchangeOffer(id,true)
                 val itemAmt = bot.bank.getAmount(id)
-                offer.amount = itemAmt
-                offer.offeredValue = checkPriceOverrides(id) ?: ItemDefinition.forId(id).value
-                SystemLogger.log("Offered " + offer.amount)
-                GEOfferDispatch.dispatch(Player(PlayerDetails.getDetails("2009scape")),offer)
+                val offeredValue = checkPriceOverrides(id) ?: ItemDefinition.forId(id).value
+                BotGrandExchange.sellOnGE(id, offeredValue, itemAmt)
+                SystemLogger.log("Offered $itemAmt")
                 bot.bank.remove(Item(id,itemAmt))
                 bot.bank.refresh()
                 SystemLogger.log("Banked fish: " + bot.bank.getAmount(ItemNames.RAW_LOBSTER))
@@ -381,11 +380,9 @@ class ScriptAPI(private val bot: Player) {
                     SystemLogger.log("Checking ${item.id}")
                     if(!item.definition.isTradeable) {continue}
                     SystemLogger.log("Adding ${item.name}")
-                    val offer = GrandExchangeOffer(item.id, true)
                     val itemAmt = item.amount
-                    offer.amount = itemAmt
-                    offer.offeredValue = checkPriceOverrides(item.id) ?: item.definition.value
-                    GEOfferDispatch.dispatch(bot, offer)
+                    val offeredValue = checkPriceOverrides(item.id) ?: item.definition.value
+                    BotGrandExchange.sellOnGE(item.id, offeredValue, itemAmt)
                     bot.bank.remove(item)
                     bot.bank.refresh()
                 }
@@ -404,12 +401,10 @@ class ScriptAPI(private val bot: Player) {
     fun sellOnGE(id: Int, value: Int){
         class toCounterPulseWithPrice : MovementPulse(bot,Location.create(3165, 3487, 0) ){
             override fun pulse(): Boolean {
-                val offer = GrandExchangeOffer(id,true)
                 val itemAmt = bot.bank.getAmount(id)
-                offer.amount = itemAmt
-                offer.offeredValue = checkPriceOverrides(id) ?: value
-                SystemLogger.log("Offered " + offer.amount)
-                GEOfferDispatch.dispatch(bot,offer)
+                val offeredValue = checkPriceOverrides(id) ?: value
+                SystemLogger.log("Offered $itemAmt")
+                BotGrandExchange.sellOnGE(id, offeredValue, itemAmt)
                 bot.bank.remove(Item(id,itemAmt))
                 bot.bank.refresh()
                 SystemLogger.log("Banked fish: " + bot.bank.getAmount(ItemNames.RAW_LOBSTER))

--- a/Server/src/main/java/Server/plugin/ge/BotGrandExchange.java
+++ b/Server/src/main/java/Server/plugin/ge/BotGrandExchange.java
@@ -20,13 +20,16 @@ public class BotGrandExchange {
         Collection<GrandExchangeOffer> offers = GEOfferDispatch.getOfferMapping().values();
         List<Long> offersToRemove = new ArrayList<Long>();
         for (GrandExchangeOffer o : offers){
-            if (o.getPlayerUID() == MAGIC_UID) {
+            if (o.getPlayerUID() == MAGIC_UID && o.isSell()) {
                 if (botOffers.containsKey(o.getItemId())) {
                     GrandExchangeOffer bo = botOffers.get(o.getItemId());
                     bo.setAmount(bo.getAmount() + o.getAmountLeft());
                     botOffers.put(o.getItemId(), bo);
                 } else {
-                    botOffers.put(o.getItemId(), o);
+                    GrandExchangeOffer bo = new GrandExchangeOffer(o.getItemId(), true);
+                    bo.setAmount(o.getAmountLeft());
+                    bo.setOfferedValue(o.getOfferedValue());
+                    botOffers.put(bo.getItemId(), bo);
                 }
                 offersToRemove.add(o.getUid());
             }

--- a/Server/src/main/java/Server/plugin/ge/BotGrandExchange.java
+++ b/Server/src/main/java/Server/plugin/ge/BotGrandExchange.java
@@ -18,6 +18,7 @@ public class BotGrandExchange {
 
     public static void loadOffersFromDB() {
         Collection<GrandExchangeOffer> offers = GEOfferDispatch.getOfferMapping().values();
+        List<Long> offersToRemove = new ArrayList<Long>();
         for (GrandExchangeOffer o : offers){
             if (o.getPlayerUID() == MAGIC_UID) {
                 if (botOffers.containsKey(o.getItemId())) {
@@ -27,8 +28,11 @@ public class BotGrandExchange {
                 } else {
                     botOffers.put(o.getItemId(), o);
                 }
-                GEOfferDispatch.remove(o.getUid());
+                offersToRemove.add(o.getUid());
             }
+        }
+        for (Long i : offersToRemove) {
+            GEOfferDispatch.remove(i);
         }
         SystemLogger.log("Extracted " + botOffers.size() + " unique items from DB. Saving...");
         for (GrandExchangeOffer o : botOffers.values()) {

--- a/Server/src/main/java/Server/plugin/ge/BotGrandExchange.java
+++ b/Server/src/main/java/Server/plugin/ge/BotGrandExchange.java
@@ -12,7 +12,7 @@ import java.util.*;
  * @author eli
  */
 public class BotGrandExchange {
-    private static HashMap<Integer, GrandExchangeOffer> botOffers;
+    private static HashMap<Integer, GrandExchangeOffer> botOffers = new HashMap<Integer, GrandExchangeOffer>();
 
     private static final int MAGIC_UID = -1031243425;
 

--- a/Server/src/main/java/Server/plugin/ge/BotGrandExchange.java
+++ b/Server/src/main/java/Server/plugin/ge/BotGrandExchange.java
@@ -1,0 +1,57 @@
+package plugin.ge;
+
+import core.game.node.entity.player.Player;
+import core.game.node.entity.player.info.PlayerDetails;
+import core.game.system.SystemLogger;
+
+import java.util.*;
+
+/**
+ * Handles the bots' Grand Exchange history.
+ *
+ * @author eli
+ */
+public class BotGrandExchange {
+    private static HashMap<Integer, GrandExchangeOffer> botOffers;
+
+    private static final int MAGIC_UID = -1031243425;
+
+    public static void loadOffersFromDB() {
+        Collection<GrandExchangeOffer> offers = GEOfferDispatch.getOfferMapping().values();
+        for (GrandExchangeOffer o : offers){
+            if (o.getPlayerUID() == MAGIC_UID) {
+                if (botOffers.containsKey(o.getItemId())) {
+                    GrandExchangeOffer bo = botOffers.get(o.getItemId());
+                    bo.setAmount(bo.getAmount() + o.getAmountLeft());
+                    botOffers.put(o.getItemId(), bo);
+                } else {
+                    botOffers.put(o.getItemId(), o);
+                }
+                GEOfferDispatch.remove(o.getUid());
+            }
+        }
+        SystemLogger.log("Extracted " + botOffers.size() + " unique items from DB. Saving...");
+        for (GrandExchangeOffer o : botOffers.values()) {
+            GEOfferDispatch.dispatch(new Player(PlayerDetails.getDetails("2009scape")), o);
+            SystemLogger.log("Selling " + o.getItemId() + " in amt " + o.getAmount());
+        }
+    }
+
+    public static void sellOnGE(int id, int value, int amount) {
+        GrandExchangeOffer o;
+        if (botOffers.containsKey(id)) {
+            o = botOffers.get(id);
+            o.setAmount(amount + o.getAmount());
+            o.setOfferedValue(value);
+            SystemLogger.log("Updated item " + id + " on GE to selling " + o.getAmount() + " items.");
+            GEOfferDispatch.setOfferMap(o);
+        } else {
+            o = new GrandExchangeOffer(id, true);
+            o.setAmount(amount);
+            o.setOfferedValue(value);
+            GEOfferDispatch.dispatch(new Player(PlayerDetails.getDetails("2009scape")), o);
+            SystemLogger.log("Adding new item " + id + " in amt " + o.getAmount());
+        }
+        botOffers.put(id, GEOfferDispatch.getOfferMapping().get(GEOfferDispatch.getLastItemUID()));
+    }
+}

--- a/Server/src/main/java/Server/plugin/ge/GEAutoStock.java
+++ b/Server/src/main/java/Server/plugin/ge/GEAutoStock.java
@@ -24,6 +24,7 @@ import javax.xml.parsers.DocumentBuilderFactory;
 /**
  * Auto stocking feature for the grand exchange. 
  * @author Ceikry
+ * @author Angle
  *
  */
 public class GEAutoStock {

--- a/Server/src/main/java/Server/plugin/ge/GEAutoStock.java
+++ b/Server/src/main/java/Server/plugin/ge/GEAutoStock.java
@@ -24,7 +24,6 @@ import javax.xml.parsers.DocumentBuilderFactory;
 /**
  * Auto stocking feature for the grand exchange. 
  * @author Ceikry
- * @author Angle
  *
  */
 public class GEAutoStock {

--- a/Server/src/main/java/Server/plugin/ge/GEOfferDispatch.kt
+++ b/Server/src/main/java/Server/plugin/ge/GEOfferDispatch.kt
@@ -32,6 +32,7 @@ class GEOfferDispatch : Pulse(), CallBack {
         init()
         delay = 1
         GameWorld.Pulser.submit(this)
+        BotGrandExchange.loadOffersFromDB()
         return true
     }
 
@@ -337,6 +338,22 @@ class GEOfferDispatch : Pulse(), CallBack {
                 nextUID()
             } else id
         }
+
+        /**
+         * Sets the offer mapping
+         */
+        @JvmStatic
+        fun setOfferMap(offer: GrandExchangeOffer) {
+            OFFER_MAPPING[offer.uid] = offer
+        }
+
+        /**
+         * Gets the current UID without incrementing for use in BotGrandExchange
+         * @return The UID
+         */
+        @JvmStatic
+        val lastItemUID: Long
+            get() = this.offsetUID
 
         /**
          * Gets the offerMapping.

--- a/Server/src/main/java/Server/plugin/ge/GEOfferDispatch.kt
+++ b/Server/src/main/java/Server/plugin/ge/GEOfferDispatch.kt
@@ -32,7 +32,6 @@ class GEOfferDispatch : Pulse(), CallBack {
         init()
         delay = 1
         GameWorld.Pulser.submit(this)
-        BotGrandExchange.loadOffersFromDB()
         return true
     }
 


### PR DESCRIPTION
Bots now hold all sold items in their own special database. The migration from the old system is totally flawless as it literally just reads in the old database every time on startup and writes an old-compatible database file on closing. The loading process for this database is slow and inefficient because of this but since it only runs once at startup and takes under a second I am willing to accept this sacrifice for compatibility.

Basically all bots now sell items as a SINGLE listing instead of as a bunch of listings.

This has the effect of reducing the database size by 10x or more, depending on how many humans you have playing on it.