### PR TITLE
Make CommunicationInfo parsing more fail-proof

### DIFF
--- a/Management-Server/src/main/java/ms/system/communication/CommunicationInfo.java
+++ b/Management-Server/src/main/java/ms/system/communication/CommunicationInfo.java
@@ -135,7 +135,7 @@ public final class CommunicationInfo {
 
 	/**
 	 * Saves the communication info.
-	 * @param buffer The buffer.
+	 * @param statement The buffer.
 	 * @throws SQLException The exception if thrown.
 	 */
 	public void save(PreparedStatement statement) throws SQLException {
@@ -164,19 +164,19 @@ public final class CommunicationInfo {
 	 */
 	public void parse(ResultSet set) throws SQLException {
 		String contacts = set.getString("contacts");
-		String[] tokens = null;
-		if (contacts != null && contacts != "") {
+		String[] tokens;
+		if (contacts != null && !contacts.isEmpty()) {
 			String[] datas = contacts.split("~");
 			for (String d : datas) {
 				tokens = d.replace("{", "").replace("}", "").split(",");
-				if (tokens.length == 0) {
+				if (tokens.length < 2) {
 					continue;
 				}
-				this.contacts.put(tokens[0], ClanRank.values()[Integer.valueOf(tokens[1])]);
+				this.contacts.put(tokens[0], ClanRank.values()[Integer.parseInt(tokens[1])]);
 			}
 		}
 		String bl = set.getString("blocked");
-		if (bl != null && bl != "") {
+		if (bl != null && !bl.isEmpty()) {
 			tokens = bl.split(",");
 			for (String name : tokens) {
 				blocked.add(name);
@@ -185,7 +185,7 @@ public final class CommunicationInfo {
 		clanName = set.getString("clanName");
 		currentClan = set.getString("currentClan");
 		String clanReqs = set.getString("clanReqs");
-		if (clanReqs != "") {
+		if (!clanReqs.isEmpty()) {
 			tokens = clanReqs.split(",");
 			ClanRank rank = null;
 			int ordinal = 0;
@@ -196,43 +196,42 @@ public final class CommunicationInfo {
 				}
 				rank = ClanRank.values()[ordinal];
 				switch (i) {
-				case 0:
-					joinRequirement = rank;
-					break;
-				case 1:
-					messageRequirement = rank;
-					break;
-				case 2:
-					if (ordinal < 3 || ordinal > 8) {
+					case 0:
+						joinRequirement = rank;
 						break;
-					}
-					kickRequirement = rank;
-					break;
-				case 3:
-					lootRequirement = rank;
-					break;
+					case 1:
+						messageRequirement = rank;
+						break;
+					case 2:
+						if (ordinal < 3 || ordinal > 8) {
+							break;
+						}
+						kickRequirement = rank;
+						break;
+					case 3:
+						lootRequirement = rank;
+						break;
 				}
 			}
 		}
 		String chatSettings = set.getString("chatSettings");
-		if (chatSettings != "") {
+		if (!chatSettings.isEmpty()) {
 			tokens = chatSettings.split(",");
 			for (int i = 0; i < tokens.length; i++) {
 				switch (i) {
-				case 0:
-					publicChatSetting = Integer.parseInt(tokens[0]);
-					break;
-				case 1:
-					privateChatSetting = Integer.parseInt(tokens[1]);
-					break;
-				case 2:
-					tradeSetting = Integer.parseInt(tokens[2]);
-					break;
+					case 0:
+						publicChatSetting = Integer.parseInt(tokens[0]);
+						break;
+					case 1:
+						privateChatSetting = Integer.parseInt(tokens[1]);
+						break;
+					case 2:
+						tradeSetting = Integer.parseInt(tokens[2]);
+						break;
 				}
 			}
 		}
 	}
-
 
 	/**
 	 * Saves the communication info.


### PR DESCRIPTION
**Describe what changes you made in this pull request, preferably with bullet points.**
* Replaced checks (`string != ""`) with working versions (`!string.isEmpty()`)
* Added a check with setting the `ClanRank` to make sure there are at least two values in the `tokens` array, to avoid a potential `IndexOutOfBoundsException`

**List the issues that this pull request closes here**
None

**Add any relevant info here**
String checks such as `string != ""` don't work in Java. This PR fixes that in the `CommunicationInfo` parsing.

Because `contacts` was an empty string on my character, splitting was done on an empty string. This returned an array with the size of 1 due to how `String.split` works in Java.

The `contacts.split("~")` line returned an array containing only an empty string. The `tokens = d.replace(...).split(",");` in the loop also returned an array containing only an empty string. That's why the `if (tokens.length == 0)` check failed, but then caused an `IndexOutOfBoundsException` as the second index of the `tokens` array was retrieved.