### PR TITLE
Let the user know if the config file can't be found, they're likely looking in wrong dir

### DIFF
--- a/Server/src/main/java/Server/core/Server.kt
+++ b/Server/src/main/java/Server/core/Server.kt
@@ -46,7 +46,7 @@ object Server {
         if (args.isNotEmpty()) {
             ServerConfigParser(args[0])
         } else {
-            println("No config file supplied! Attempting to use default...")
+            println("Using config file worldprops/default.json")
             ServerConfigParser("worldprops/default.json")
         }
         if (GameWorld.getSettings()!!.isGui) {

--- a/Server/src/main/java/Server/core/game/system/config/ServerConfigParser.kt
+++ b/Server/src/main/java/Server/core/game/system/config/ServerConfigParser.kt
@@ -24,7 +24,7 @@ class ServerConfigParser(path: String) {
 
     init {
         if(!confFile.exists()){
-            println("File specified for the config file does not exist!!")
+            println("Could not find ${confFile.canonicalFile} - Double check your working directory!")
         } else if(!pathTo.contains(".json")) {
             println("Config file MUST be a JSON file!!")
             println("(Got $pathTo)")


### PR DESCRIPTION
Right now, the config file cannot be found 9 times out of 10 because the working dir is incorrectly set. We used to have a message like this before I changed all the config locs and broke everything that seems to have been reverted :shrug: 

Updated PR to push into main branch :facepalm: 