### PR TITLE
Fixed multiple achievement diary tasks

### DIFF
--- a/Server/src/main/java/Server/plugin/activity/partyroom/BalloonManager.java
+++ b/Server/src/main/java/Server/plugin/activity/partyroom/BalloonManager.java
@@ -243,6 +243,10 @@ public final class BalloonManager extends OptionHandler {
 			ObjectBuilder.add(popped);
 			getBalloons().remove(object);
 			player.animate(Animation.create(10017));
+
+			// Pop a party balloon
+			player.getAchievementDiaryManager().finishTask(player, DiaryType.FALADOR, 0, 12);
+
 			GameWorld.getPulser().submit(new Pulse(1) {
 				int counter;
 
@@ -257,7 +261,6 @@ public final class BalloonManager extends OptionHandler {
 								GroundItemManager.create(ground);
 								PartyRoomPlugin.getPartyChest().shift();
 								PartyRoomPlugin.update();
-								player.getAchievementDiaryManager().finishTask(player,DiaryType.FALADOR, 0, 12);
 							}
 						}
 						return true;

--- a/Server/src/main/java/Server/plugin/jobs/WorkForOptionHandler.kt
+++ b/Server/src/main/java/Server/plugin/jobs/WorkForOptionHandler.kt
@@ -7,6 +7,7 @@ import core.game.interaction.OptionHandler
 import core.game.node.Node
 import core.game.node.entity.npc.NPC
 import core.game.node.entity.player.Player
+import core.game.node.entity.player.link.diary.DiaryType
 import core.game.node.item.Item
 import core.plugin.InitializablePlugin
 import core.plugin.Plugin
@@ -95,6 +96,9 @@ class WorkForOptionHandler : OptionHandler() {
             0 -> {
                 val job = GatheringJobs.values()[jobId]
                 player.dialogueInterpreter.sendItemMessage(job.itemId,"You are assigned to gather $amount ${Item(job.itemId).name.toLowerCase()}")
+
+                // Have the Fishing Tutor send you on an errand
+                if (node.id == 4901) player.achievementDiaryManager.finishTask(player, DiaryType.LUMBRIDGE, 0, 14);
             }
             1 -> {
                 val job = SlayingJob.values()[jobId]

--- a/Server/src/main/java/Server/plugin/npc/other/LumbridgeSwampGiantRatNPC.java
+++ b/Server/src/main/java/Server/plugin/npc/other/LumbridgeSwampGiantRatNPC.java
@@ -45,7 +45,9 @@ public class LumbridgeSwampGiantRatNPC extends AbstractNPC {
     @Override
     public void finalizeDeath(final Entity killer) {
         super.finalizeDeath(killer);
-        if (killer instanceof Player && killer.getViewport().getRegion().getId() == 12593) {
+
+        // Kill a giant rat in Lumbridge Swamp
+        if (killer instanceof Player && (killer.getViewport().getRegion().getId() == 12593 || killer.getViewport().getRegion().getId() == 12849)) {
             killer.asPlayer().getAchievementDiaryManager().finishTask(killer.asPlayer(), DiaryType.LUMBRIDGE, 1, 7);
         }
     }

--- a/Server/src/main/java/Server/plugin/quest/free/dragonslayer/DukeHoracioDialogue.java
+++ b/Server/src/main/java/Server/plugin/quest/free/dragonslayer/DukeHoracioDialogue.java
@@ -103,6 +103,7 @@ public final class DukeHoracioDialogue extends DialoguePlugin {
                         GroundItemManager.create(DragonSlayer.SHIELD, player);
                     }
                     interpreter.sendItemMessage(DragonSlayer.SHIELD, "The Duke hands you a heavy orange shield.");
+                    // Obtain an Anti-dragonbreath shield from Duke Horacio
                     player.getAchievementDiaryManager().finishTask(player, DiaryType.LUMBRIDGE, 2, 5);
                     stage = 412;
                     break;
@@ -259,6 +260,8 @@ public final class DukeHoracioDialogue extends DialoguePlugin {
 		npc = (NPC) args[0];
 		interpreter.sendDialogues(npc, FacialExpression.HALF_GUILTY, "Greetings. Welcome to my castle.");
 		stage = 0;
+        // Speak to the Duke of Lumbridge
+        player.getAchievementDiaryManager().finishTask(player, DiaryType.LUMBRIDGE, 0, 2);
 		return true;
 	}
 
@@ -285,6 +288,8 @@ public final class DukeHoracioDialogue extends DialoguePlugin {
 				GroundItemManager.create(DragonSlayer.SHIELD, player);
 			}
 			interpreter.sendItemMessage(DragonSlayer.SHIELD, "The Duke hands you the shield.");
+            // Obtain an Anti-dragonbreath shield from Duke Horacio
+            player.getAchievementDiaryManager().finishTask(player, DiaryType.LUMBRIDGE, 2, 5);
 			stage = 805;
 			break;
 		case 805:

--- a/Server/src/main/java/Server/plugin/skill/cooking/StandardCookingPulse.java
+++ b/Server/src/main/java/Server/plugin/skill/cooking/StandardCookingPulse.java
@@ -171,15 +171,17 @@ public class StandardCookingPulse extends Pulse {
                 player.getInventory().add(productItem);
                 player.getSkills().addExperience(Skills.COOKING, experience, true);
 
+                int playerRegion = player.getViewport().getRegion().getId();
+
                 // Achievement Diary Handling
                 if (productItem.getId() == ItemNames.BASS
-                        && player.getViewport().getRegion().getId() == 11317
+                        && playerRegion == 11317
                         && player.getAttribute("diary:seers:bass-caught", false)) {
                     player.getAchievementDiaryManager().finishTask(player, DiaryType.SEERS_VILLAGE, 1, 11);
                 }
 
                 if (productItem.getId() == ItemNames.SHARK
-                        && player.getViewport().getRegion().getId() == 11317
+                        && playerRegion == 11317
                         && player.getEquipment().get(EquipmentContainer.SLOT_HANDS).getId() == ItemNames.COOKING_GAUNTLETS_775
                         && !player.getAchievementDiaryManager().hasCompletedTask(DiaryType.SEERS_VILLAGE, 2, 8)) {
                     player.setAttribute("/save:diary:seers:cooked-shark", 1 + player.getAttribute("diary:seers:cooked-shark", 0));
@@ -190,7 +192,7 @@ public class StandardCookingPulse extends Pulse {
 
                 // Cook some rat meat on a campfire in Lumbridge Swamp
                 System.out.println(object.getName());
-                if (initialItem.getId() == ItemNames.RAW_RAT_MEAT && object.getName().toLowerCase().contains("fire") && player.getViewport().getRegion().getId() == 12593) {
+                if (initialItem.getId() == ItemNames.RAW_RAT_MEAT && object.getName().toLowerCase().contains("fire") && (playerRegion == 12593 || playerRegion == 12849)) {
                     player.getAchievementDiaryManager().finishTask(player, DiaryType.LUMBRIDGE, 1, 10);
                 }
 

--- a/Server/src/main/java/Server/plugin/skill/farming/patch/PickingNode.java
+++ b/Server/src/main/java/Server/plugin/skill/farming/patch/PickingNode.java
@@ -54,15 +54,18 @@ public class PickingNode extends FarmingNode {
 		return super.getNextStage(cycle);
 	}
 
+	boolean hasFaladorShield(Player player) {
+		Item shield = player.getEquipment().get(EquipmentContainer.SLOT_SHIELD);
+		return shield != null && (shield.getId() == 14577 || shield.getId() == 14580);
+	}
+
 	@Override
 	public void checkHealth(final PatchCycle cycle) {
 		final Player player = cycle.getPlayer();
 		cycle.addConfigValue(getPickedBase(maxPick));
 		double xp = getExperiences()[2];
-		// Check for falador shield bonus
-		int shieldId = player.getEquipment().get(EquipmentContainer.SLOT_SHIELD).getId();
-		if ((shieldId == DiaryType.FALADOR.getRewards(1)[0].getId() || shieldId==DiaryType.FALADOR.getRewards(2)[0].getId())
-				&& player.getLocation().withinDistance(PatchProtection.FALADOR.getFlowerLocation(), 20)) {
+		// Check for Falador shield bonus
+		if (hasFaladorShield(player) && player.getLocation().withinDistance(PatchProtection.FALADOR.getFlowerLocation(), 20)) {
 			xp = xp * 1.1;
 		}
 		player.getSkills().addExperience(Skills.FARMING, xp, true);
@@ -77,9 +80,7 @@ public class PickingNode extends FarmingNode {
 		player.getInventory().add(getProduct());
 		double xp = getExperiences()[1];
 		// Check for falador shield bonus
-		int shieldId = player.getEquipment().get(EquipmentContainer.SLOT_SHIELD).getId();
-		if ((shieldId == DiaryType.FALADOR.getRewards(1)[0].getId() || shieldId==DiaryType.FALADOR.getRewards(2)[0].getId())
-				&& player.getLocation().withinDistance(PatchProtection.FALADOR.getFlowerLocation(), 20)) {
+		if (hasFaladorShield(player) && player.getLocation().withinDistance(PatchProtection.FALADOR.getFlowerLocation(), 20)) {
 			xp = xp * 1.1;
 		}
 		player.getSkills().addExperience(Skills.FARMING, xp, true);

--- a/Server/src/main/java/Server/plugin/skill/farming/tool/RakePulse.java
+++ b/Server/src/main/java/Server/plugin/skill/farming/tool/RakePulse.java
@@ -57,10 +57,8 @@ public final class RakePulse extends ToolAction {
 			if (player.getInventory().add(FarmingConstant.WEEDS)) {
 				wrapper.addConfigValue(wrapper.getState() + 1);
 				double xp = 4;
-				// Check for falador shield bonus
-				int shieldId = player.getEquipment().get(EquipmentContainer.SLOT_SHIELD).getId();
-				if ((shieldId == DiaryType.FALADOR.getRewards(1)[0].getId() || shieldId==DiaryType.FALADOR.getRewards(2)[0].getId())
-						&& player.getLocation().withinDistance(PatchProtection.FALADOR.getFlowerLocation(), 20)) {
+				// Check for Falador shield bonus
+				if (hasFaladorShield(player) && player.getLocation().withinDistance(PatchProtection.FALADOR.getFlowerLocation(), 20)) {
 					xp = xp * 1.1;
 				}
 				player.getSkills().addExperience(Skills.FARMING, xp, true);
@@ -89,4 +87,8 @@ public final class RakePulse extends ToolAction {
 		return true;
 	}
 
+	boolean hasFaladorShield(Player player) {
+		Item shield = player.getEquipment().get(EquipmentContainer.SLOT_SHIELD);
+		return shield != null && (shield.getId() == 14577 || shield.getId() == 14580);
+	}
 }

--- a/Server/src/main/java/Server/plugin/skill/farming/tool/SpadePulse.java
+++ b/Server/src/main/java/Server/plugin/skill/farming/tool/SpadePulse.java
@@ -147,10 +147,8 @@ public final class SpadePulse extends ToolAction {
 					if (wrapper.getPatch() == FarmingPatch.TREE) {
 						double xp = 6;
 
-						// Check for falador shield bonus
-						int shieldId = player.getEquipment().get(EquipmentContainer.SLOT_SHIELD) == null ? 0 : player.getEquipment().get(EquipmentContainer.SLOT_SHIELD).getId();
-						if ((shieldId == DiaryType.FALADOR.getRewards(1)[0].getId() || shieldId==DiaryType.FALADOR.getRewards(2)[0].getId())
-								&& player.getLocation().withinDistance(PatchProtection.FALADOR.getFlowerLocation(), 20)) {
+						// Check for Falador shield bonus
+						if (hasFaladorShield(player) && player.getLocation().withinDistance(PatchProtection.FALADOR.getFlowerLocation(), 20)) {
 							xp = xp * 1.1;
 						}
 						player.getSkills().addExperience(Skills.FARMING, xp, true);
@@ -185,10 +183,8 @@ public final class SpadePulse extends ToolAction {
 		final Item item = wrapper.getNode().getProduct();
 	    player.getInventory().add(item);
 		double xp = wrapper.getNode().getExperiences()[1];
-		// Check for falador shield bonus
-		int shieldId = player.getEquipment().get(EquipmentContainer.SLOT_SHIELD) == null ? 0 : player.getEquipment().get(EquipmentContainer.SLOT_SHIELD).getId();
-		if ((shieldId == DiaryType.FALADOR.getRewards(1)[0].getId() || shieldId==DiaryType.FALADOR.getRewards(2)[0].getId())
-				&& player.getLocation().withinDistance(PatchProtection.FALADOR.getFlowerLocation(), 20)) {
+		// Check for Falador shield bonus
+		if (hasFaladorShield(player) && player.getLocation().withinDistance(PatchProtection.FALADOR.getFlowerLocation(), 20)) {
 			xp = xp * 1.1;
 		}
 		player.getSkills().addExperience(Skills.FARMING, xp, true);
@@ -259,4 +255,8 @@ public final class SpadePulse extends ToolAction {
 		return true;
 	}
 
+	boolean hasFaladorShield(Player player) {
+		Item shield = player.getEquipment().get(EquipmentContainer.SLOT_SHIELD);
+		return shield != null && (shield.getId() == 14577 || shield.getId() == 14580);
+	}
 }

--- a/Server/src/main/java/Server/plugin/skill/farming/wrapper/PatchInteractor.java
+++ b/Server/src/main/java/Server/plugin/skill/farming/wrapper/PatchInteractor.java
@@ -121,6 +121,11 @@ public final class PatchInteractor {
 		player.getPulseManager().run(action);
 	}
 
+	boolean hasFaladorShield(Player player) {
+		Item shield = player.getEquipment().get(EquipmentContainer.SLOT_SHIELD);
+		return shield != null && (shield.getId() == 14577 || shield.getId() == 14580);
+	}
+
 	/**
 	 * Method used to apply compost to a patch.
 	 * @param item the item.
@@ -143,10 +148,8 @@ public final class PatchInteractor {
 		player.animate(COMPOST_ANIMATION);
 		player.getInventory().replace(FarmingConstant.BUCKET, item.getSlot());
 		double xp = 18;
-		// Check for falador shield bonus
-		int shieldId = player.getEquipment().get(EquipmentContainer.SLOT_SHIELD).getId();
-		if ((shieldId == DiaryType.FALADOR.getRewards(1)[0].getId() || shieldId==DiaryType.FALADOR.getRewards(2)[0].getId())
-				&& player.getLocation().withinDistance(PatchProtection.FALADOR.getFlowerLocation(), 20)) {
+		// Check for Falador shield bonus
+		if (hasFaladorShield(player) && player.getLocation().withinDistance(PatchProtection.FALADOR.getFlowerLocation(), 20)) {
 			xp = xp * 1.1;
 		}
 		player.getSkills().addExperience(Skills.FARMING, xp, true);
@@ -207,10 +210,8 @@ public final class PatchInteractor {
 				@Override
 				public boolean pulse() {
 					double xp = node.getExperiences()[0];
-					// Check for falador shield bonus
-					int shieldId = player.getEquipment().get(EquipmentContainer.SLOT_SHIELD).getId();
-					if ((shieldId == DiaryType.FALADOR.getRewards(1)[0].getId() || shieldId==DiaryType.FALADOR.getRewards(2)[0].getId())
-							&& player.getLocation().withinDistance(PatchProtection.FALADOR.getFlowerLocation(), 20)) {
+					// Check for Falador shield bonus
+					if (hasFaladorShield(player) && player.getLocation().withinDistance(PatchProtection.FALADOR.getFlowerLocation(), 20)) {
 						xp = xp * 1.1;
 					}
 					player.getSkills().addExperience(Skills.FARMING, xp, true);
@@ -261,10 +262,8 @@ public final class PatchInteractor {
 				public boolean pulse() {
 					player.getInventory().add(wrapper.getNode().getProduct(), player);
 					double xp = wrapper.getNode().getExperiences()[1];
-					// Check for falador shield bonus
-					int shieldId = player.getEquipment().get(EquipmentContainer.SLOT_SHIELD).getId();
-					if ((shieldId == DiaryType.FALADOR.getRewards(1)[0].getId() || shieldId==DiaryType.FALADOR.getRewards(2)[0].getId())
-							&& player.getLocation().withinDistance(PatchProtection.FALADOR.getFlowerLocation(), 20)) {
+					// Check for Falador shield bonus
+					if (hasFaladorShield(player) && player.getLocation().withinDistance(PatchProtection.FALADOR.getFlowerLocation(), 20)) {
 						xp = xp * 1.1;
 					}
 					player.getSkills().addExperience(Skills.FARMING, xp, true);

--- a/Server/src/main/java/Server/plugin/skill/firemaking/FireMakingPulse.java
+++ b/Server/src/main/java/Server/plugin/skill/firemaking/FireMakingPulse.java
@@ -140,12 +140,13 @@ public final class FireMakingPulse extends SkillPulse<Item> {
 		}
 		player.getSkills().addExperience(Skills.FIREMAKING,fire.getXp());
 
+		int playerRegion = player.getViewport().getRegion().getId();
 
-		if (fire == Log.MAGIC && player.getLocation().getRegionId() == 10806) {
+		if (fire == Log.MAGIC && playerRegion == 10806) {
 			player.getAchievementDiaryManager().finishTask(player,DiaryType.SEERS_VILLAGE,2, 5);
 		}
 		// Light a campfire from normal logs in Lumbridge Swamp
-		if (fire == Log.NORMAL && player.getViewport().getRegion().getId() == 12593) {
+		if (fire == Log.NORMAL && (playerRegion == 12593 || playerRegion == 12849)) {
 			player.getAchievementDiaryManager().finishTask(player, DiaryType.LUMBRIDGE, 1, 9);
 		}
 		// Light a willow log fire in Lumbridge Castle courtyard

--- a/Server/src/main/java/Server/plugin/skill/gather/woodcutting/WoodcuttingSkillPulse.java
+++ b/Server/src/main/java/Server/plugin/skill/gather/woodcutting/WoodcuttingSkillPulse.java
@@ -260,11 +260,13 @@ public class WoodcuttingSkillPulse extends Pulse {
             player.getAchievementDiaryManager().finishTask(player, DiaryType.KARAMJA, 1, 8);
         }
 
+        int playerRegion = player.getViewport().getRegion().getId();
+
         // Chop down a dying tree in the Lumber Yard
-        if (node.getId() == 24168 && player.getViewport().getRegion().getId() == 13110) {
+        if (node.getId() == 24168 && playerRegion == 13110) {
             player.getAchievementDiaryManager().finishTask(player, DiaryType.VARROCK, 0, 6);
         }
-        if (resource == WoodcuttingNode.YEW && player.getViewport().getRegion().getId() == 10806) {
+        if (resource == WoodcuttingNode.YEW && playerRegion == 10806) {
             if (!player.getAchievementDiaryManager().hasCompletedTask(DiaryType.SEERS_VILLAGE, 2, 1)) {
                 player.setAttribute("/save:diary:seers:cut-yew", player.getAttribute("diary:seers:cut-yew", 0) + 1);
             }
@@ -285,12 +287,12 @@ public class WoodcuttingSkillPulse extends Pulse {
         }
 
         // Cut down a dead tree in Lumbridge Swamp
-        if (resource.name().toLowerCase().startsWith("dead") && player.getViewport().getRegion().getId() == 12593) {
+        if (resource.name().toLowerCase().startsWith("dead") && (playerRegion == 12593 || playerRegion == 12849)) {
             player.getAchievementDiaryManager().finishTask(player, DiaryType.LUMBRIDGE, 1, 8);
         }
 
         // Cut a willow tree, east of Lumbridge Castle
-        if (resource.name().toLowerCase().startsWith("willow") && player.getViewport().getRegion().getId() == 12850) {
+        if (resource.name().toLowerCase().startsWith("willow") && playerRegion == 12850) {
             player.getAchievementDiaryManager().finishTask(player, DiaryType.LUMBRIDGE, 2, 6);
         }
     }

--- a/build-singleplayer.bat
+++ b/build-singleplayer.bat
@@ -24,10 +24,10 @@ copy /Y "Server\build\libs\server-1.0.0.jar" "Single-Player\server.jar"
 echo.
 
 echo Copying server data...
-del Single-Player/data
+del /S /Q "Single-Player/data"
 xcopy /E /I /Y "Server\data" "Single-Player\data"
 xcopy /E /I /Y "Server\db_exports\*.sql" "Single-Player\data"
-del Single-Player/worldprops
+del /S /Q "Single-Player/worldprops"
 xcopy /E /I /Y "Server\worldprops" "Single-Player\worldprops"
 : Set Debug/Dev mode to false on single player server config
 powershell -Command "(gc Single-Player\worldprops\default.json) -replace '\"debug\": true', '\"debug\": false' -replace '\"dev\": true', '\"dev\": false' | Out-File -Encoding Default Single-Player\worldprops\default.json"


### PR DESCRIPTION
Tasks fixed:
- Speak to the Duke of Lumbridge
- Obtain an Anti-dragonbreath shield from Duke Horacio
- Kill a giant rat in Lumbridge Swamp
- Cut down a dead tree in Lumbridge Swamp
- Light a campfire from normal logs in Lumbridge Swamp
- Cook some rat meat on a campfire in Lumbridge Swamp
- Have the Fishing Tutor send you on an errand
- Pop a party balloon

Fixed Falador shield related NPEs