### PR TITLE
Alphabetize the ::quests list so that it's easier to find a specific quest

### DIFF
--- a/Server/src/main/java/Server/core/game/system/command/sets/QuestCommandSet.kt
+++ b/Server/src/main/java/Server/core/game/system/command/sets/QuestCommandSet.kt
@@ -58,7 +58,7 @@ class QuestCommandSet : CommandSet(Command.Privilege.ADMIN){
         }
         var lineId = 11
         player.packetDispatch.sendString("<col=ecf0f1>" + "Available Quests" + "</col>", 275, 2)
-        for (q in QuestRepository.getQuests().values) {
+        for (q in QuestRepository.getQuests().toSortedMap().values) {
             // Add a space to beginning and end of string for the strikethrough
             player.packetDispatch.sendString("<col=ecf0f1>" + (if (q.isCompleted(player)) "<str> " else "") + q.name + " ", 275, lineId++)
         }


### PR DESCRIPTION
Currently the order seems to be in whatever order the server decides to register quests. Let's sort it so that users can find a specific quest easily.