### PR TITLE
Reduce the low-quality news spam of bots selling 2 ashes, 1 logs, etc

### DIFF
--- a/Server/src/main/java/Server/plugin/ai/general/ScriptAPI.kt
+++ b/Server/src/main/java/Server/plugin/ai/general/ScriptAPI.kt
@@ -382,7 +382,7 @@ class ScriptAPI(private val bot: Player) {
                     actualId = Item(id).noteChange
                 }
                 val canSell = OfferManager.addBotOffer(actualId, itemAmt)
-                if (canSell) {
+                if (canSell && saleIsBigNews(actualId, itemAmt)) {
                     SystemLogger.log("Offered $itemAmt")
                     Repository.sendNews("2009Scape just offered " + itemAmt + " " + ItemDefinition.forId(actualId).name.toLowerCase() + " on the GE.")
                 }
@@ -415,7 +415,7 @@ class ScriptAPI(private val bot: Player) {
                         actualId = Item(actualId).noteChange
                     }
                     val canSell = OfferManager.addBotOffer(actualId, itemAmt)
-                    if (canSell) {
+                    if (canSell && saleIsBigNews(actualId, itemAmt)) {
                         Repository.sendNews("2009Scape just offered " + itemAmt + " " + ItemDefinition.forId(actualId).name.toLowerCase() + " on the GE.")
                     }
                     bot.bank.remove(item)
@@ -444,7 +444,7 @@ class ScriptAPI(private val bot: Player) {
                         actualId = Item(actualId).noteChange
                     }
                     val canSell = OfferManager.addBotOffer(actualId, itemAmt)
-                    if (canSell) {
+                    if (canSell && saleIsBigNews(actualId, itemAmt)) {
                         Repository.sendNews("2009Scape just offered " + itemAmt + " " + ItemDefinition.forId(actualId).name.toLowerCase() + " on the GE.")
                     }
                     bot.bank.remove(item)
@@ -454,6 +454,17 @@ class ScriptAPI(private val bot: Player) {
             }
         }
         bot.pulseManager.run(toCounterPulseAll())
+    }
+
+    /**
+     * Function to determine whether or not to bother everyone on the server
+     * with the big news that a bot is selling something to the GE, based on item value
+     * @param itemID
+     * @param amount
+     * @author Gexja
+     */
+    fun saleIsBigNews(itemID: Int, amount: Int): Boolean {
+        return ItemDefinition.forId(itemID).getAlchemyValue(true) * amount >= 500
     }
 
     /**


### PR DESCRIPTION
I found the spam of 
```
NEWS: 2009SCAPE OFFERED 1 ASHES FOR SALE 
NEWS: 2009SCAPE OFFERED 3 LOGS FOR SALE
NEWS: 2009SCAPE OFFERED 8 AIR RUNES FOR SALE
NEWS: 2009SCAPE OFFERED 2 ARROW SHAFTS FOR SALE
NEWS: 2009SCAPE OFFERED 4 LOGS FOR SALE
```
every few minutes to be undesirable. The user usually can't use this information, or doesn't care. It's nice to know when an actual player offers an item for sale, because they are part of the community, but the bots offer low quality trades constantly & it's not like I'm going to stop what I'm doing to go buy the 2 mind runes that are now fore sale. When the player is ready to buy an item, they will go to the GE and place an offer.

I would recommend this approach of checking if the item stack is valuable OR just don't make an annoucement at all.