### PR TITLE
Bump Client discord-rpc

### DIFF
--- a/Client/build.gradle
+++ b/Client/build.gradle
@@ -4,8 +4,12 @@ archivesBaseName = 'client'
 
 mainClassName = 'org.rs09.client.GameLaunch'
 
+repositories {
+    maven { url 'https://jitpack.io' }
+}
+
 dependencies {
-    implementation 'com.github.Vatuu:discord-rpc:1.6.2'
+    implementation 'com.github.Vatuu:discord-rpc:1f829371af'
     implementation 'com.googlecode.json-simple:json-simple:1.1.1'
 
     implementation files('libs/clientlibs.jar')


### PR DESCRIPTION
Dependency was [recently updated ](https://github.com/Vatuu/discord-rpc/pull/49) to fix a SIGSEGV when running multiple instances under linux.

Alternatively if building against jitpack/github is not an option, I have another branch that adds a config flag to control the initialization of the discord rpc.