### PR TITLE
Don't load Discord libs on aarch64

### DIFF
--- a/Client/src/main/java/org/runite/client/Client.java
+++ b/Client/src/main/java/org/runite/client/Client.java
@@ -144,8 +144,10 @@ public final class Client extends GameShell {
                     }
                 }
                 if (Class143.loadingStage == 0) {
-                    // Discord
-                    Discord.InitalizeDiscord();
+                    // Don't load Discord on ARM
+		    if (!System.getProperty("os.arch").contains("aarch64")) {
+                        Discord.InitalizeDiscord();
+                    }
                     Class3_Sub28_Sub1.updateLoadingBar((Color) null, var10, Class3_Sub17.aClass94_2464, LoadingStageNumber);
                 } else if (5 == Class143.loadingStage) {
                     Class3_Sub23.method406((byte) 117, false, Class168.aClass3_Sub28_Sub17_2096);


### PR DESCRIPTION
**Describe what changes you made in this pull request, preferably with bullet points.**
* Check the contents of the `os.arch` string and only load the Discord plugin on x86 systems
 
**List the issues that this pull request closes here**
* Closes #778

**Add any relevant info here**
There are probably several other ways to do this, including catching any exception(s) from when the Discord plugin fails to load, instead of letting it hang the client indefinitely

Tested this on amd64 Linux and aarch64 Linux, client is able to launch and fully load to login screen with no issues
