### PR TITLE
Fixed bug where player could walk when crossing stepping stones, resu…

### DIFF
--- a/Server/src/main/java/Server/core/game/node/entity/skill/agility/WildernessCourse.kt
+++ b/Server/src/main/java/Server/core/game/node/entity/skill/agility/WildernessCourse.kt
@@ -174,7 +174,7 @@ class WildernessCourse
      * @param object the object.
      */
     private fun handleSteppingStones(player: Player, `object`: GameObject) {
-        player.locks.lockInteractions(12)
+        player.lock(13)
         val fail = AgilityHandler.hasFailed(player, 1, 0.3)
         player.addExtension(LogoutTask::class.java, LocationLogoutTask(12, player.location))
         GameWorld.Pulser.submit(object : Pulse(2, player) {


### PR DESCRIPTION
**Changes:**
* Players can no longer walk for a small time period after clicking "Cross Stepping stone" in Wilderness Agility Course. This prevents the player from getting stuck on one of the stepping stones. (Thanks LZ#9801 for reporting it)