### PR TITLE
Fix 5 option dialogue swords

### DIFF
--- a/Server/src/main/java/Server/core/game/content/dialogue/DialogueInterpreter.java
+++ b/Server/src/main/java/Server/core/game/content/dialogue/DialogueInterpreter.java
@@ -74,6 +74,7 @@ public final class DialogueInterpreter {
                     new int[] {6, 9},
                     new int[] {7, 10},
                     new int[] {8, 9},
+                    new int[] {9, 10},
             };
 
     /**


### PR DESCRIPTION
Adds swords for interface 234 (5 options)

Example: Exception when trying to speak with Doric:

```
java.lang.ArrayIndexOutOfBoundsException: 3
	at core.game.content.dialogue.DialogueInterpreter.sendOptions(DialogueInterpreter.java:530)
	at core.game.content.dialogue.DoricDialogue.handle(DoricDialogue.java:74)
	at core.game.content.dialogue.DialogueInterpreter.handle(DialogueInterpreter.java:185)
	at core.net.packet.in.ActionButtonPacket.getArguments(ActionButtonPacket.java:174)
	at core.net.packet.in.ActionButtonPacket.decode(ActionButtonPacket.java:30)
	at core.net.event.GameReadEvent.read(GameReadEvent.java:107)
	at core.net.IoReadEvent.run(IoReadEvent.java:45)
	at java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1149)
	at java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:624)
	at java.lang.Thread.run(Thread.java:748)
```
