### PR TITLE
Fixed bug in Gnome Stronghold agility shortcut to barb outpost

### DIFF
--- a/Server/src/main/java/Server/core/game/interaction/city/GnomeStrongholdPlugin.java
+++ b/Server/src/main/java/Server/core/game/interaction/city/GnomeStrongholdPlugin.java
@@ -42,7 +42,7 @@ public final class GnomeStrongholdPlugin extends OptionHandler {
 		case 9317:
 			final boolean scale = player.getLocation().getY() <= object.getLocation().getY();
 			final Location end = object.getLocation().transform(scale ? 3 : -3, scale ? 6 : -6, 0);
-			if (player.getSkills().hasLevel(Skills.AGILITY, 37)) {
+			if (!player.getSkills().hasLevel(Skills.AGILITY, 37)) {
 				player.getPacketDispatch().sendMessage("You must be level 37 agility or higher to climb down the rocks.");
 				break;
 			}


### PR DESCRIPTION
The failure message indicates we should be checking that the player does not have the required level, not that they do.

Currently, you can use this shortcut before level 37, but not after.

**Describe what changes you made in this pull request, preferably with bullet points.**
* Fixed bug in Gnome stronghold agility shortcut check

**List the issues that this pull request closes here**
<br/>
-None

**Add any relevant info here**
<br/>
-Example: Only partially resolves the overall issue, still need to make x changes...
