### PR TITLE
Added barrels with swamp tar as they existed when Lunar quest was added

### DIFF
--- a/Server/src/main/java/Server/core/game/interaction/object/LadyTayOptionPlugin.java
+++ b/Server/src/main/java/Server/core/game/interaction/object/LadyTayOptionPlugin.java
@@ -1,0 +1,44 @@
+package core.game.interaction.object;
+
+import core.cache.def.impl.NPCDefinition;
+import core.cache.def.impl.ObjectDefinition;
+import core.game.component.Component;
+import core.game.interaction.OptionHandler;
+import core.game.node.Node;
+import core.game.node.entity.player.Player;
+import core.game.node.object.GameObject;
+import core.plugin.Initializable;
+import core.plugin.Plugin;
+
+/**
+ * Adds a barrel from which you can take swamp tar on the Lady Tay
+ * @author f00b
+ */
+@Initializable
+public class LadyTayOptionsPlugin extends OptionHandler {
+
+    @Override
+    public Plugin<Object> newInstance(Object arg) throws Throwable {
+        /* the tar barrels on the lower deck of the Lady Zay */
+        ObjectDefinition.forId(16860).getHandlers().put("option:take-from", this);
+    }
+
+    @Override
+    public boolean handle(Player player, Node node, String option) {
+        int id = node instanceof GameObject ? ((GameObject) node).getId() : ((NPC) node).getId();
+        final Item tar = new Item(1939); // Swamp tar
+        switch (option) {
+        case "take-from":
+            if (id == 16860) {
+                if (!player.getInventory.hasSpaceFor(add)) {
+                    player.getPacketDispatch().sendMessage("Not enough space in your inventory!");
+                    return true;
+                }
+                player.getInventory().add(tar);
+                player.getPacketDispatch().sendMessage("You take some tar from the barrel.");
+                return true;
+            }
+        }
+        return false;
+    }
+}


### PR DESCRIPTION
**Describe what changes you made in this pull request, preferably with bullet points.**
* The Lady Tay (the pirate boat from Pirate's cove) has some barrels below deck that give the player swamp tar, 1 at a time. These barrels were added with Lunar's quest in 2006.

**List the issues that this pull request closes here**
<br/>
-None

**Add any relevant info here**
<br/>
-Needs to be tested, but may also be possible to verify it's correct just by looking at it. Working on getting a build set up locally and will update when I've had a chance to test. If you could send me my player save file it would greatly expedite the testing process!
