### PR TITLE
Drop explorer: A set of Python classes for exploring drop tables as if they're the underlying JSON

### DIFF
--- a/Server/data/configs/item_configs.json
+++ b/Server/data/configs/item_configs.json
@@ -295,6 +295,15 @@
       "archery_ticket_price": "0",
       "durability": null
     },
+		{
+		  "id": "31",
+			"name": "Tinderbox",
+			"examine": "Useful for lighting a fire.",
+			"low_alchemy": "0",
+			"high_alchemy": "0",
+			"weight": "0.1",
+			"durability": null
+		},
     {
       "id": "32",
       "name": "Lit black candle",

--- a/Server/data/configs/item_configs.json
+++ b/Server/data/configs/item_configs.json
@@ -295,15 +295,15 @@
       "archery_ticket_price": "0",
       "durability": null
     },
-		{
-		  "id": "31",
-			"name": "Tinderbox",
-			"examine": "Useful for lighting a fire.",
-			"low_alchemy": "0",
-			"high_alchemy": "0",
-			"weight": "0.1",
-			"durability": null
-		},
+    {
+      "id": "31",
+      "name": "Tinderbox",
+      "examine": "Useful for lighting a fire.",
+      "low_alchemy": "0",
+      "high_alchemy": "0",
+      "weight": "0.1",
+      "durability": null
+    },
     {
       "id": "32",
       "name": "Lit black candle",

--- a/Tools/drop_explorer.py
+++ b/Tools/drop_explorer.py
@@ -1,0 +1,312 @@
+import sys
+import json
+import argparse
+import os
+import re
+
+source_files = "../Server/data/configs/{npc_configs,item_configs,drop_tables}.json"
+
+def json_root_name(path):
+    '''Given a path to a json file path, 
+    return the string before '.json' and after the last "/"
+    '''
+    return os.path.basename(os.path.splitext(path)[0])
+
+assert json_root_name("../Server/data/configs/item_configs.json") == "item_configs", "Failed to parse out root object name from JSON path"
+
+"""
+Compute the Damerau-Levenshtein distance between two given
+strings (s1 and s2)
+
+From here: https://www.guyrutenberg.com/2008/12/15/damerau-levenshtein-distance-in-python/
+"""
+def damerau_levenshtein_distance(s1, s2):
+    d = {}
+    lenstr1 = len(s1)
+    lenstr2 = len(s2)
+    for i in range(-1,lenstr1+1):
+        d[(i,-1)] = i+1
+    for j in range(-1,lenstr2+1):
+        d[(-1,j)] = j+1
+
+    for i in range(lenstr1):
+        for j in range(lenstr2):
+            if s1[i] == s2[j]:
+                cost = 0
+            else:
+                cost = 1
+            d[(i,j)] = min(
+                           d[(i-1,j)] + 1, # deletion
+                           d[(i,j-1)] + 1, # insertion
+                           d[(i-1,j-1)] + cost, # substitution
+                          )
+            if i and j and s1[i]==s2[j-1] and s1[i-1] == s2[j]:
+                d[(i,j)] = min (d[(i,j)], d[i-2,j-2] + cost) # transposition
+
+    return d[lenstr1-1,lenstr2-1]
+
+class Item:
+    attributes = {"id"
+        , "name"
+        , "examine"
+        , "destroy"
+        , "tradeable"
+        , "destroy_message"
+        , "shop_price"
+        , "weight"
+        , "archery_ticket_price"
+        , "durability"
+        , "low_alchemy"
+        , "high_alchemy"
+        , "grand_exchange_price"
+        , "ge_buy_limit"
+        , "requirements"
+        , "render_anim"
+        , "equipment_slot"
+        , "attack_speed"
+        , "bonuses"
+        , "weapon_interface"
+        , "has_special"
+        , "attack_anims"
+        , "defence_anim"
+        , "attack_audios"
+        , "remove_head"
+        , "remove_sleeves"
+        , "tokkul_price"
+        , "bankable"
+        , "stand_anim"
+        , "walk_anim"
+        , "run_anim"
+        , "stand_turn_anim"
+        , "turn180_anim"
+        , "turn90cw_anim"
+        , "turn90ccw_anim"
+        , "two_handed"
+        , "absorb"
+        , "point_price"
+        , "lendable"
+        , "fun_weapon"
+        , "rare_item"
+        , "remove_beard"
+    }
+    def __init__(self, item_dict, reporter=None):
+        for attribute in self.attributes:
+            self.__dict__[attribute] = None
+        for attribute, value in item_dict.items():
+            if attribute not in self.attributes:
+                if reporter:
+                    reporter.report(attribute)
+                else:
+                    raise AttributeError(f"Unhandled item attribute '{attribute}'")
+            self.__dict__[attribute] = value
+
+
+class Drop:
+    attributes = {
+       "minAmount"
+       , "weight"
+       , "id"
+       , "maxAmount" 
+    }
+    def __init__(self, drop_dict, storage=None, reporter=None):
+        for attribute in self.attributes:
+            self.__dict__[attribute] = None
+        for attribute, value in drop_dict.items():
+            if attribute not in self.attributes:
+                if reporter:
+                    reporter.report(attribute)
+                else:
+                    raise AttributeError(f"Unhandled item attribute '{attribute}'")
+            self.__dict__[attribute] = value
+        
+        #'''
+        if self.id not in storage.item_id_to_item:
+            print("Item in drop table is NOT in the item configs:", item_dict)
+        #'''
+        self.item = storage.item_id_to_item.get(self.id, None)
+
+class DropTable:
+    attributes = {
+        "ids"
+        , "main"
+        , "charm"
+        , "default"
+        , "description"
+    }
+    def __init__(self, table_dict, storage=None, reporter=None):
+        for attribute in self.attributes:
+            self.__dict__[attribute] = None
+        for attribute, value in table_dict.items():
+            if attribute not in self.attributes:
+                if reporter:
+                    reporter.report(attribute)
+                else:
+                    raise AttributeError(f"Unhandled item attribute '{attribute}'")
+            self.__dict__[attribute] = value
+
+        self.npcs = self.ids.split(',')
+        self.drops = [Drop(drop, storage, reporter) 
+            for drop in self.main
+        ]
+
+class Reporter:
+    def __init__(self):
+        self.cache = set()
+    def report(self, item):
+        self.cache.add(item)
+    def __repr__(self):
+        return str(self.cache)
+
+class LookupStorage:
+    '''Simple object to parse and store the parsed JSON dictionaries as attributes'''
+    lookups = ["npc_configs", "item_configs", "drop_tables"]
+    root_path = "../Server/data/configs/"
+    def __init__(self, root_path=None):
+        self.attributes = {}
+
+        if root_path is None:
+            root_path = self.root_path
+        
+        for lookup in self.lookups:
+            filename = f"{os.path.join(root_path, lookup + '.json')}"
+            try:
+                with open(filename, 'r') as f:
+                    self.attributes[lookup] = json.load(f)
+            except OSError:
+                print(f"Unable to find file {filename}, are you sure you have the right path?"
+                    , file=sys.stderr
+                )
+                raise
+            except json.JSONDecodeError:
+                print(f"Error parsing {filename}, is it a valid JSON object?"
+                    , file=sys.stderr
+                )
+
+        # setup fuzzy search table
+        self.npc_names = [npc['name'] 
+            for npc in self.npc_configs
+                if 'name' in npc
+        ]
+
+        self.item_names = [item['name']
+            for item in self.item_configs
+                if 'name' in item
+        ]
+
+        # Assuming every item has an id, so we dont have to check for it
+        # This MUST be initialized before the drop tables!
+        self.item_id_to_item = {item['id'] : Item(item)
+            for item in self.item_configs
+        }
+
+        self.droptables = [DropTable(table, self)
+            for table in self.drop_tables
+        ]
+
+        self.npc_id_to_droptable = {_id : table
+            for table in self.droptables for _id in table.npcs
+        }
+
+        self.item_name_to_item = {item['name'] : Item(item)
+            for item in self.item_configs
+                if 'name' in item
+        }
+
+        # Maps from name->ID for cross referencing
+        self.npc_name_to_id = {npc['name'] : npc['id']
+            for npc in self.npc_configs
+                if 'name' in npc
+        }
+
+    def __getattr__(self, attr):
+        if (res := self.__dict__.get(attr, None)) is not None:
+            return res
+        if (res := self.attributes.get(attr, None)) is not None:
+            return res
+        raise AttributeError
+
+    def fuzzyname_to_name(self, fuzzy, candidates):
+        '''Implement an approximate string matching strategy to guess which name the user means'''
+        # making everything lower case makes it easier to work with!
+        fuzzy = fuzzy.lower()
+
+        # Replace common abbreviations with something closer to what we'll find
+        replacements = [ 
+            ('abby', 'abyssal'), 
+            ('addy', 'adamant'),
+            ('mith', 'mithril'),
+            (' legs', ' platelegs'),
+            (' skirt', ' plateskirt')
+            
+        ]
+        orig = fuzzy[:] # make a copy of the original string and try both
+        for common, real in replacements:
+            fuzzy = fuzzy.replace(common, real)
+
+        min_string = None
+        min_distance = 10000
+        for query in [fuzzy]:
+            for name in candidates:
+                if (distance := damerau_levenshtein_distance(name.lower(), query)) < min_distance:
+                    min_distance = distance
+                    min_string = name
+
+        return min_string
+
+    def fuzzyname_to_npc_id(self, fuzzy):
+        return self.npc_name_to_id.get(
+            self.fuzzyname_to_name(fuzzy, self.npc_names)
+            , None
+        )
+    def droptable_from_npc_name(self, name):
+        npcid = self.fuzzyname_to_npc_id(name)
+        table = self.npc_id_to_droptable.get(npcid, None)
+        return table
+
+    def calc_alch_value(storage, name, include_rare=False, min_alch_value=1500, verbose=True):
+        '''Find alch value of drop table of a given monster
+        
+        Sum up everything in name's drop table that alchs for more than min_alch_value
+        Normalize by weight. If the drop can be multiple, only take 1 item into account,
+        because you need 1 nat per alch anyways.
+
+        That may be wrong but for big ticket items (eg rune) it wont matter, and
+        that's the goal anyways!
+        '''
+
+        total_alch = 0
+        total_weight = 0
+        table = storage.droptable_from_npc_name(name)
+        for drop in table.drops:
+            weight = int(drop.weight)
+            total_weight = total_weight + weight
+            if (gp := drop.item.high_alchemy):
+                gp = int(gp)
+                if not include_rare and bool(drop.item.rare_item):
+                    continue
+                if gp < min_alch_value:
+                    continue
+                if verbose:
+                    print(f"Found alchable in table: {drop.item.name} for {gp}gp")
+                total_alch = total_alch + weight * gp
+
+        # Average alchable gp per kill
+        return int(total_alch / total_weight)
+
+    @staticmethod
+    def test():
+        tester = LookupStorage()
+        _ = tester.npc_configs
+        _ = tester.item_configs
+        _ = tester.drop_tables
+
+        assert tester.fuzzyname_to_name("Abby demon", tester.npc_names) == "Abyssal demon"
+        assert tester.fuzzyname_to_name("Mith Legs", tester.item_names) == "Mithril platelegs"
+
+        print(tester.calc_alch_value("Dark beast"), "alchable gp per dark beast kill!")
+        
+LookupStorage.test()
+
+            
+   # table = DropTable(
+    


### PR DESCRIPTION
**Describe what changes you made in this pull request, preferably with bullet points.**
* Added a tool called `drop_explorer.py` that contains some classes you can use to look into drop tables.
* `LookupStorage` class: an object containing the parsed JSON data, as well as some helpful methods for operating on it
    * on init, this class automatically attempts to parse the JSON data in this project, assuming you ran the script from the `Tools/` directory. You can change where it looks for the JSON data by passing the optional `root_path` keyword argument to the constructor.
    * After init completes successfully (takes a few seconds to slurp the data and setup lookup tables), it has `LookupStorage.item_configs, LookupStorage.npc_configs, and LookupStorage.drop_tables`, which are the parsed dictionaries representing the underlying JSON. 
* `Item` class: all Item objects contain all possible item attributes, exactly as written in the JSON. For example, `Item({id:"1001"}).id == "1001"`
* `DropTable` class: similarly contains all attributes from the JSON, in addition to:
    * `DropTable.npcs`: a list of strings representing the IDs of NPCs that have this drop table
    * `DropTable.drops`: a list of `Drop` objects constructed from the content of the `main` key
* `Drop` class: again, all attributes from the JSON, in addition to:
    * `Drop.item`: an `Item` object constructed from `Drop.id`


**List the issues that this pull request closes here**
<br/>
-N/A

**Add any relevant info here**
<br/>
-Currently requires Python3.8+
-To change what it does (which is currently just some testing + calculating the most valuable drop tables by alch), you must write additional code. 
-An interactive CLI mode and some additional lookup functionality is in the works!
-cleaned up the git history in this PR