### PR TITLE
Increase abby whip drop chance

### DIFF
--- a/Server/data/configs/drop_tables.json
+++ b/Server/data/configs/drop_tables.json
@@ -26224,7 +26224,7 @@
       },
       {
         "minAmount": "1",
-        "weight": "1",
+        "weight": "2",
         "id": "4151",
         "maxAmount": "1"
       },


### PR DESCRIPTION
- Increase abby whip drop chance to 1/528.5 instead of 1/1056
OSRS wiki shows rate of 1/512 for the whip and there are no sources to suggest it should be any different for 2009
https://oldschool.runescape.wiki/w/Abyssal_demon
https://runescape.wiki/w/Abyssal_demon?oldid=894947